### PR TITLE
Fix missing voice settings in text-to-speech

### DIFF
--- a/src/SentenceStudio/Pages/Shadowing/ShadowingPage.cs
+++ b/src/SentenceStudio/Pages/Shadowing/ShadowingPage.cs
@@ -1189,7 +1189,7 @@ partial class ShadowingPage : Component<ShadowingPageState, ActivityProps>
     private string FormatTimeDisplay(double timeInSeconds)
     {
         if (timeInSeconds < 0)
-            return "--:--";
+            return "--:--.---";
             
         TimeSpan time = TimeSpan.FromSeconds(timeInSeconds);
         return $"{time.Minutes:00}:{time.Seconds:00}.{time.Milliseconds:000}";

--- a/src/SentenceStudio/Services/ElevenLabsSpeechService.cs
+++ b/src/SentenceStudio/Services/ElevenLabsSpeechService.cs
@@ -142,16 +142,22 @@ public class ElevenLabsSpeechService
                 voiceId = VoiceOptions[voiceId];
             }
 
-            // Create the voice settings
+            // Create the voice settings including speed
             var voiceSettings = new VoiceSettings(
-                stability: stability, 
-                similarityBoost: similarityBoost);
+                stability: stability,
+                similarityBoost: similarityBoost)
+            {
+                Speed = speed
+            };
                 
             var voice = await _client.VoicesEndpoint
                 .GetVoiceAsync(voiceId, cancellationToken: cancellationToken);
 
-            // Create audio generation options
-            var request = new TextToSpeechRequest(voice, text, model: Model.MultiLingualV2);//eleven_multilingual_v2
+            // Create audio generation options including voice settings
+            var request = new TextToSpeechRequest(voice, text, model: Model.MultiLingualV2)
+            {
+                VoiceSettings = voiceSettings
+            };//eleven_multilingual_v2
 
             // Generate the speech using the proper API call
             var audioBytes = await _client.TextToSpeechEndpoint.TextToSpeechAsync(


### PR DESCRIPTION
## Summary
- wire up speed and voice settings when generating speech via ElevenLabs
- standardize time display placeholder formatting

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c15c87b648331b7eb7c09e9b6f540