### PR TITLE
Fix syntactic analysis logging

### DIFF
--- a/src/SentenceStudio/Services/SyntacticAnalysisService.cs
+++ b/src/SentenceStudio/Services/SyntacticAnalysisService.cs
@@ -51,7 +51,7 @@ public class SyntacticAnalysisService
         catch (Exception ex)
         {
             // Handle any exceptions that occur during the process
-            Debug.WriteLine($"An error occurred GetChallenges: {ex.Message}");
+            Debug.WriteLine($"An error occurred GetSentences: {ex.Message}");
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- update `SyntacticAnalysisService` error message to reference GetSentences

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1a21fefc8331a81e308ec612246e