### PR TITLE
Fix ContinueConversation method typo

### DIFF
--- a/src/SentenceStudio/Pages/Warmup/WarmupPage.cs
+++ b/src/SentenceStudio/Pages/Warmup/WarmupPage.cs
@@ -314,7 +314,7 @@ partial class WarmupPage : Component<WarmupPageState>
         var chunk = new ConversationChunk(_conversation.ID, DateTime.Now, ConversationParticipant.Bot.FirstName, "...");
         SetState(s => s.Chunks.Add(chunk));
 
-        Reply response = await _conversationService.ContinueConveration(State.Chunks.ToList());
+        Reply response = await _conversationService.ContinueConversation(State.Chunks.ToList());
         chunk.Text = response.Message;
 
         var previousChunk = State.Chunks[State.Chunks.Count - 2];

--- a/src/SentenceStudio/Services/ConversationService.cs
+++ b/src/SentenceStudio/Services/ConversationService.cs
@@ -92,7 +92,7 @@ namespace SentenceStudio.Services
             }
         }   
 
-        public async Task<Reply> ContinueConveration(List<ConversationChunk> chunks)
+        public async Task<Reply> ContinueConversation(List<ConversationChunk> chunks)
         {       
             var prompt = string.Empty;     
             using Stream templateStream = await FileSystem.OpenAppPackageFileAsync("ContinueConversation.scriban-txt");


### PR DESCRIPTION
## Summary
- rename ContinueConveration method in `ConversationService` to `ContinueConversation`
- update WarmupPage to use corrected method name

## Testing
- `dotnet build src/SentenceStudio.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1a1bd36c83319a196af40e59ce09