### PR TITLE
fix: preserve vocabulary list filter state across navigation

### DIFF
--- a/src/SentenceStudio.UI/Pages/Vocabulary.razor
+++ b/src/SentenceStudio.UI/Pages/Vocabulary.razor
@@ -848,8 +848,15 @@ else
     private static string TruncateTitle(string? title, int maxLen) =>
         title == null ? "" : title.Length <= maxLen ? title : title[..maxLen] + "…";
 
-    private void AddWord() => NavManager.NavigateTo("/vocabulary/edit/0");
-    private void EditWord(string id) => NavManager.NavigateTo($"/vocabulary/edit/{id}");
+    private void AddWord() => NavManager.NavigateTo(BuildEditUrl("0"));
+    private void EditWord(string id) => NavManager.NavigateTo(BuildEditUrl(id));
+
+    private string BuildEditUrl(string id)
+    {
+        if (string.IsNullOrWhiteSpace(searchQuery))
+            return $"/vocabulary/edit/{id}";
+        return $"/vocabulary/edit/{id}?returnQuery={Uri.EscapeDataString(searchQuery)}";
+    }
 
     private void OnCardClick(VocabularyCardItem item)
     {

--- a/src/SentenceStudio.UI/Pages/VocabularyWordEdit.razor
+++ b/src/SentenceStudio.UI/Pages/VocabularyWordEdit.razor
@@ -229,6 +229,9 @@ else
 @code {
     [Parameter] public string Id { get; set; } = "";
 
+    [SupplyParameterFromQuery(Name = "returnQuery")]
+    public string? ReturnQuery { get; set; }
+
     [Inject] private LearningResourceRepository ResourceRepo { get; set; } = default!;
     [Inject] private VocabularyProgressService ProgressService { get; set; } = default!;
     [Inject] private NavigationManager NavManager { get; set; } = default!;
@@ -503,7 +506,13 @@ else
         }
     }
 
-    private void GoBack() => NavManager.NavigateTo("/vocabulary");
+    private void GoBack()
+    {
+        var url = string.IsNullOrWhiteSpace(ReturnQuery)
+            ? "/vocabulary"
+            : $"/vocabulary?q={Uri.EscapeDataString(ReturnQuery)}";
+        NavManager.NavigateTo(url);
+    }
 
     private async Task SetStatus(SentenceStudio.Shared.Models.LearningStatus status)
     {


### PR DESCRIPTION
Fixes #133

## Problem
When a user applies search/filter on the Vocabulary page, clicks into a word detail, then navigates back — filters and search are reset. User loses their place.

## Solution
**Query string approach** — the simplest option that works with browser history:

- **`Vocabulary.razor`**: `EditWord` and `AddWord` now pass the current search query as a `returnQuery` URL parameter when navigating to the edit page.
- **`VocabularyWordEdit.razor`**: Reads `returnQuery` from the URL via `[SupplyParameterFromQuery]` and uses it in `GoBack()` to restore the filter state.

Flow: `/vocabulary?q=tag:food` → `/vocabulary/edit/abc?returnQuery=tag%3Afood` → back → `/vocabulary?q=tag%3Afood` (filters restored)