### PR TITLE
fix(mobile): HttpClient instrumentation via DelegatingHandler for mobile↔API correlation

### DIFF
--- a/src/SentenceStudio.AppLib/ServiceCollectionExtentions.cs
+++ b/src/SentenceStudio.AppLib/ServiceCollectionExtentions.cs
@@ -4,10 +4,12 @@ using CoreSync.Sqlite;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using SentenceStudio.Services;
 using SentenceStudio.Services.Api;
 using SentenceStudio.Services.Agents;
+using SentenceStudio.Services.Observability;
 using SentenceStudio.Shared.Models;
 
 
@@ -37,11 +39,17 @@ public static class ServiceCollectionExtentions
             return new SqliteSyncProvider(configurationBuilder.Build(), ProviderMode.Local, new SyncLogger(serviceProvider.GetRequiredService<ILogger<SyncLogger>>()));
         });
 
+        services.TryAddApiActivityHandler();
+
         services.AddHttpClient("HttpClientToServer", httpClient =>
         {
             httpClient.BaseAddress = serverUri;
             httpClient.Timeout = TimeSpan.FromMinutes(10);
         })
+        // ApiActivityHandler goes FIRST so the Activity wraps the full request including
+        // auth token attachment — gives us accurate latency and a single span per call.
+        // With the Activity current, HttpClient's DiagnosticsHandler auto-injects traceparent.
+        .AddHttpMessageHandler<ApiActivityHandler>()
         .AddHttpMessageHandler<AuthenticatedHttpMessageHandler>();
 
         services.AddCoreSyncHttpClient(options =>
@@ -57,6 +65,8 @@ public static class ServiceCollectionExtentions
         services.AddAuthorizationCore();
         services.AddScoped<AuthenticationStateProvider, MauiAuthenticationStateProvider>();
 
+        services.TryAddApiActivityHandler();
+
         // Register a named HttpClient for auth endpoints (login, register, refresh).
         // Uses the same API base URL as other clients but without the auth handler
         // to avoid a circular dependency (auth client cannot require auth).
@@ -67,7 +77,8 @@ public static class ServiceCollectionExtentions
             {
                 client.BaseAddress = apiBaseUri;
                 client.Timeout = TimeSpan.FromSeconds(15);
-            });
+            })
+            .AddHttpMessageHandler<ApiActivityHandler>();
         }
 
         services.AddTransient<AuthenticatedHttpMessageHandler>();
@@ -76,16 +87,35 @@ public static class ServiceCollectionExtentions
 
     public static void AddApiClients(this IServiceCollection services, Uri baseUri)
     {
+        services.TryAddApiActivityHandler();
+
         services.AddHttpClient<IAiApiClient, AiApiClient>(client => client.BaseAddress = baseUri)
+            .AddHttpMessageHandler<ApiActivityHandler>()
             .AddHttpMessageHandler<AuthenticatedHttpMessageHandler>();
         services.AddHttpClient<ISpeechApiClient, SpeechApiClient>(client => client.BaseAddress = baseUri)
+            .AddHttpMessageHandler<ApiActivityHandler>()
             .AddHttpMessageHandler<AuthenticatedHttpMessageHandler>();
         services.AddHttpClient<IPlansApiClient, PlansApiClient>(client => client.BaseAddress = baseUri)
+            .AddHttpMessageHandler<ApiActivityHandler>()
             .AddHttpMessageHandler<AuthenticatedHttpMessageHandler>();
         services.AddHttpClient<IFeedbackApiClient, FeedbackApiClient>(client => client.BaseAddress = baseUri)
+            .AddHttpMessageHandler<ApiActivityHandler>()
             .AddHttpMessageHandler<AuthenticatedHttpMessageHandler>();
         services.AddSingleton<IAiGatewayClient, AiGatewayClient>();
         services.AddSingleton<ISpeechGatewayClient, SpeechGatewayClient>();
+    }
+
+    /// <summary>
+    /// Registers <see cref="ApiActivityHandler"/> as transient (the required lifetime
+    /// for <see cref="DelegatingHandler"/>s consumed by <c>HttpClientFactory</c>).
+    /// Safe to call multiple times — uses TryAdd semantics so the several
+    /// entry points (<c>AddApiClients</c>, <c>AddAuthServices</c>, <c>AddSyncServices</c>,
+    /// and the <c>VersionCheckService</c> registration) don't step on each other.
+    /// </summary>
+    internal static IServiceCollection TryAddApiActivityHandler(this IServiceCollection services)
+    {
+        services.TryAddTransient<ApiActivityHandler>();
+        return services;
     }
 
     class SyncLogger(ILogger<SyncLogger> logger) : ISyncLogger

--- a/src/SentenceStudio.AppLib/Services/Observability/ApiActivityHandler.cs
+++ b/src/SentenceStudio.AppLib/Services/Observability/ApiActivityHandler.cs
@@ -113,9 +113,10 @@ public sealed class ApiActivityHandler : DelegatingHandler
         }
         catch (Exception ex)
         {
+            // RecordException emits a standard OTel "exception" event with type/message/stacktrace,
+            // which surfaces in App Insights' exception timeline. Keep status error for queryability.
+            activity.AddException(ex);
             activity.SetStatus(ActivityStatusCode.Error, ex.Message);
-            activity.SetTag("exception.type", ex.GetType().FullName);
-            activity.SetTag("exception.message", ex.Message);
             _logger?.LogDebug(ex, "API HttpClient call failed: {Method} {Uri}", method, uri);
             throw;
         }

--- a/src/SentenceStudio.AppLib/Services/Observability/ApiActivityHandler.cs
+++ b/src/SentenceStudio.AppLib/Services/Observability/ApiActivityHandler.cs
@@ -1,0 +1,123 @@
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace SentenceStudio.Services.Observability;
+
+/// <summary>
+/// Delegating handler that starts a <see cref="System.Diagnostics.Activity"/> per outbound HTTP request
+/// so that mobile→API calls propagate a W3C <c>traceparent</c> header and show up as dependencies
+/// in Application Insights linked to the server-side request by <c>operation_Id</c>.
+///
+/// <para>
+/// Background: <c>OpenTelemetry.Instrumentation.Http</c>'s auto-instrumentation relies on the
+/// <see cref="System.Diagnostics.ActivitySource"/> it registers being active at the time HttpClient
+/// sends a request. On a full <see cref="Microsoft.Extensions.Hosting.IHost"/>, that happens via
+/// <c>TelemetryHostedService.StartAsync</c> which materialises the <c>TracerProvider</c> and its
+/// listeners. MAUI <c>MauiApp</c> doesn't run <see cref="Microsoft.Extensions.Hosting.IHostedService"/>,
+/// so the provider can end up unstarted — logs still flow (they hook <c>ILoggerFactory</c> directly)
+/// but no HTTP dependency spans are produced and no <c>traceparent</c> is emitted.
+/// </para>
+///
+/// <para>
+/// This handler sidesteps the lifecycle issue by using a dedicated <see cref="ActivitySource"/>
+/// that the MAUI service defaults explicitly <c>.AddSource(...)</c> to the <c>TracerProvider</c>.
+/// Once an <see cref="Activity"/> is current, HttpClient's built-in <c>DiagnosticsHandler</c>
+/// injects the W3C headers for us — we never touch <c>request.Headers</c> directly. That means
+/// if the framework-level MAUI/OTel lifecycle gap is ever fixed (see follow-up issue), this
+/// handler remains correct and non-duplicative; if it isn't fixed, this handler is what makes
+/// correlation work at all.
+/// </para>
+/// </summary>
+public sealed class ApiActivityHandler : DelegatingHandler
+{
+    /// <summary>
+    /// Well-known <see cref="ActivitySource"/> name. Must be registered on the mobile
+    /// <c>TracerProvider</c> (see <c>SentenceStudio.MauiServiceDefaults.Extensions</c>) or
+    /// spans will be created but never exported.
+    /// </summary>
+    public const string ActivitySourceName = "SentenceStudio.Mobile.HttpClient";
+
+    private static readonly ActivitySource Source = new(ActivitySourceName);
+
+    private readonly ILogger<ApiActivityHandler>? _logger;
+
+    public ApiActivityHandler(ILogger<ApiActivityHandler>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        // Skip activity creation if the request somehow has no URI — defensive only.
+        if (request.RequestUri is null)
+        {
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        var method = request.Method.Method;
+        var uri = request.RequestUri;
+
+        // OTel HTTP semantic-convention-ish name: "HTTP {METHOD} {path}". Keep it short enough
+        // to be readable in App Insights but informative for debugging.
+        var activityName = $"HTTP {method} {uri.AbsolutePath}";
+
+        using var activity = Source.StartActivity(activityName, ActivityKind.Client);
+
+        // If no listener is attached (source not registered on the TracerProvider, or provider
+        // not materialised), StartActivity returns null. In that case we still want the call
+        // to succeed — we just skip the telemetry bookkeeping.
+        if (activity is null)
+        {
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Standard HTTP tags (OpenTelemetry semantic conventions).
+        activity.SetTag("http.request.method", method);
+        activity.SetTag("url.full", uri.ToString());
+        activity.SetTag("url.scheme", uri.Scheme);
+        activity.SetTag("server.address", uri.Host);
+        if (!uri.IsDefaultPort)
+        {
+            activity.SetTag("server.port", uri.Port);
+        }
+
+        try
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            var statusCode = (int)response.StatusCode;
+            activity.SetTag("http.response.status_code", statusCode);
+
+            // 4xx is client-side failure, 5xx is server-side — both warrant Error status in OTel.
+            if (statusCode >= 400)
+            {
+                activity.SetStatus(ActivityStatusCode.Error, $"HTTP {statusCode}");
+            }
+            else
+            {
+                activity.SetStatus(ActivityStatusCode.Ok);
+            }
+
+            return response;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // User/caller cancelled — not an application error. Record-but-don't-fail.
+            activity.SetStatus(ActivityStatusCode.Error, "cancelled");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            activity.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity.SetTag("exception.type", ex.GetType().FullName);
+            activity.SetTag("exception.message", ex.Message);
+            _logger?.LogDebug(ex, "API HttpClient call failed: {Method} {Uri}", method, uri);
+            throw;
+        }
+    }
+}

--- a/src/SentenceStudio.AppLib/Setup/SentenceStudioAppBuilder.cs
+++ b/src/SentenceStudio.AppLib/Setup/SentenceStudioAppBuilder.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Maui;
 using CommunityToolkit.Maui.Storage;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using OpenAI;
 using ElevenLabs;
@@ -214,9 +215,11 @@ public static class SentenceStudioAppBuilder
         services.AddSingleton<ReleaseNotesService>();
 
         // Version check service — calls API to detect available updates (mobile only)
+        services.TryAddApiActivityHandler();
         services.AddHttpClient<VersionCheckService>(client =>
         {
             client.BaseAddress = new Uri("https+http://api");
-        });
+        })
+        .AddHttpMessageHandler<SentenceStudio.Services.Observability.ApiActivityHandler>();
     }
 }

--- a/src/SentenceStudio.MauiServiceDefaults/Extensions.cs
+++ b/src/SentenceStudio.MauiServiceDefaults/Extensions.cs
@@ -86,6 +86,12 @@ public static class Extensions
                 //tracing.AddSource("Microsoft.Maui");
                 
                 tracing.AddSource(builder.Environment.ApplicationName)
+                    // Manual API-call activities from ApiActivityHandler. Needed because
+                    // MAUI doesn't run IHostedService, which means the OTel auto-
+                    // instrumentation for HttpClient may not start its ActivitySource
+                    // listeners. See SentenceStudio.Services.Observability.ApiActivityHandler
+                    // for the full rationale + follow-up issue link.
+                    .AddSource("SentenceStudio.Mobile.HttpClient")
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
                     .AddHttpClientInstrumentation();
@@ -100,9 +106,14 @@ public static class Extensions
     {
         public void Initialize(IServiceProvider services)
         {
-            services.GetService<MeterProvider>();
-            services.GetService<TracerProvider>();
-            services.GetService<LoggerProvider>();
+            // GetRequiredService (vs GetService) guarantees construction — if the provider
+            // isn't registered we want a hard failure at startup instead of silently-broken
+            // telemetry later. MAUI doesn't run IHostedService, so this forced resolution
+            // is what actually materialises the providers. See ApiActivityHandler docs for
+            // the full story and the tracked framework-level follow-up.
+            services.GetRequiredService<MeterProvider>();
+            services.GetRequiredService<TracerProvider>();
+            services.GetRequiredService<LoggerProvider>();
         }
     }
 


### PR DESCRIPTION
## What

Restores mobile↔API correlation in Application Insights by wrapping every API-bound mobile `HttpClient` with a manual `ApiActivityHandler` `DelegatingHandler` that starts a `Client` Activity per outbound request. With `Activity.Current` non-null, HttpClient auto-injects the W3C `traceparent` header, which propagates `operation_Id` from mobile through the server request.

## Why

PR #165 (mobile App Insights bootstrap) + PR #166 (server companion) shipped the end-to-end telemetry plumbing, but the `requests | join traces on operation_Id` correlation query returned **zero rows**. Every server request showed `operation_Id == operation_ParentId`, meaning no `traceparent` was arriving from the device.

Two incorrect diagnoses during this investigation (see session log), finally landing on:

- **`AddHttpClientInstrumentation()` was already wired** (since commit 216a2da1, March 4) — my first "fix" would have been a no-op.
- **Trimming is not the cause** — a Release build with `<MtouchLink>None</MtouchLink>` (136 MB, 333 DLLs) on DX24 produced the same 0-dependency result.
- **Root cause** (tracked in #171): MAUI's `MauiApp` doesn't run `IHostedService` instances, so `TelemetryHostedService` — which normally materializes the `TracerProvider` and attaches its listeners — never runs. Logs still work (they hook `ILoggerFactory` synchronously), but auto HTTP instrumentation does not.

## How

- **New: `ApiActivityHandler`** — dedicated `ActivitySource` (`SentenceStudio.Mobile.HttpClient`), `Client` kind, OTel-conformant tags (`http.request.method`, `url.full`, `server.address`, `http.response.status_code`), error status on exception + `>=400`, proper `Activity` disposal.
- **`MauiServiceDefaults.Extensions`**:
  - `.AddSource("SentenceStudio.Mobile.HttpClient")` on the `TracerProvider` so the new spans actually export.
  - `GetRequiredService<T>()` instead of nullable `GetService<T>()` for all three providers so silent misregistration becomes a loud startup failure.
- **`ServiceCollectionExtentions` + `SentenceStudioAppBuilder`** — handler placed FIRST in each chain (ahead of `AuthenticatedHttpMessageHandler`) so the span covers the full operation including auth token attachment. Registered via `TryAddTransient<>()` so the several entry points don't step on each other.

## Verification

- Mac Catalyst Debug: `0 Error(s)` / 571 warnings ✅
- Mac Catalyst Release: `0 Error(s)` / 689 warnings ✅
- Post-merge: iOS Release publish to DX24 + KQL query confirming non-empty `operation_ParentId` on server requests — Captain's call on timing.

## Out of scope

- Root-cause fix for the `IHostedService` gap (#171).
- Raw `new HttpClient()` in `SentenceStudio.Shared/Services/AiService.cs:93` — bypasses the factory; separate refactor.
- Deploy runbook KQL corrections (joins the wrong tables on both sides) — separate docs PR.

## Risk

- Low: handler returns early if `Source.StartActivity(...)` yields null (no listener attached), so behavior is identical to the current code path on any surface where the source isn't registered.
- Medium: `GetRequiredService` change converts a silent failure into a startup crash if providers aren't registered. This is intentional — today's silent failure is the reason we're here.

## Follow-ups

- #171 — force `TracerProvider` materialization without `IHostedService`
