### PR TITLE
fix(mobile): explicitly inject traceparent for mobile↔API correlation

### DIFF
--- a/src/SentenceStudio.AppLib/Services/Observability/ApiActivityHandler.cs
+++ b/src/SentenceStudio.AppLib/Services/Observability/ApiActivityHandler.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -84,6 +85,31 @@ public sealed class ApiActivityHandler : DelegatingHandler
         if (!uri.IsDefaultPort)
         {
             activity.SetTag("server.port", uri.Port);
+        }
+
+        // Explicit W3C traceparent propagation. HttpClient's built-in DiagnosticsHandler
+        // normally injects traceparent automatically, but ONLY when an OTel-style
+        // ActivityListener is attached to "System.Net.Http". On MAUI the listener never
+        // attaches because IHostedService doesn't run (see issue #171). Without this
+        // block, the API sees every request as a root operation and the App Insights
+        // correlation join against mobile dependencies returns zero rows — the exact
+        // symptom PR #172 partially fixed (spans emit) but couldn't close out.
+        //
+        // We only inject if no traceparent already exists on the request so that a
+        // deliberate upstream caller can override (and so repeated retries via the
+        // standard resilience handler don't duplicate the header).
+        if (!request.Headers.Contains("traceparent"))
+        {
+            DistributedContextPropagator.Current.Inject(
+                activity,
+                request.Headers,
+                static (carrier, name, value) =>
+                {
+                    if (carrier is HttpRequestHeaders headers && !string.IsNullOrEmpty(value))
+                    {
+                        headers.TryAddWithoutValidation(name, value);
+                    }
+                });
         }
 
         try


### PR DESCRIPTION
## Summary

Explicitly inject W3C `traceparent` into outbound HttpClient requests from mobile so the API can correlate its spans against ours.

## Why

PR #172 added `ApiActivityHandler` which creates an Activity per request (so App Insights dependencies now carry `operation_Id`). But the correlation join still returned zero rows:

```kusto
requests
| where cloud_RoleName endswith "SentenceStudio.Api"
| join kind=inner (dependencies | where cloud_RoleName == "SentenceStudio.Mobile") on operation_Id
```

Evidence after #172:
- Q1 (mobile deps with operation_Id): **44 rows** ✅
- Q2 (correlation join): **0 rows** ❌

Diagnosis: `HttpClient`'s built-in `DiagnosticsHandler` only injects `traceparent` automatically when an `ActivityListener` is attached to `"System.Net.Http"`. On MAUI that listener never attaches because OpenTelemetry's `TelemetryHostedService` — which materializes the `TracerProvider` and its listeners — depends on `IHostedService`, and `MauiApp` doesn't run hosted services. Tracked in #171.

## What changed

In `ApiActivityHandler.SendAsync`, after the activity null-check and tag-setting, call `DistributedContextPropagator.Current.Inject(...)` on the request headers. Guarded by `!request.Headers.Contains("traceparent")` so deliberate upstream callers and resilience retries don't produce duplicate headers.

## Why this is the right scope

- Minimal surface: 26 lines in one file, no new dependencies.
- Uses `DistributedContextPropagator.Current` (W3C by default in .NET 8+), not a captured instance — safe if runtime defaults change.
- Doesn't affect the null-activity early-return path.
- Complements rather than replaces the framework fix tracked in #171; #171 is now lower priority.

## Verification

1. Build Mac Catalyst Debug + Release ✅ (compile clean; pre-existing universal-bundle plist merge issue is unrelated).
2. Publish to DX24 via iOS Release.
3. Re-run Q2 correlation join ~2 min after generating traffic. Expected: > 0 rows.

Refs: #165 #166 #172 #171
