### PR TITLE
fix: add 'type' to vocabulary search filter parser (#179)

### DIFF
--- a/.squad/agents/kaylee/history.md
+++ b/.squad/agents/kaylee/history.md
@@ -184,3 +184,28 @@ Zoe's M.E.AI 10.5 strategic recommendations executed via three-agent orchestrati
 
 **Build:** ✅ 0 errors, 107 pre-existing warnings
 
+
+## Learnings
+
+### Razor source generator regression (net11p3) — switch-expr-of-RenderFragment-with-inline-markup
+**Date:** $(date +%Y-%m-%d)
+**File:** `src/SentenceStudio.UI/Pages/ImportContent.razor`
+
+**The broken pattern:** A `static RenderFragment Helper(T x) => x switch { Case => (__builder) => { <span>...</span> }, ... };` — switch expression returning multiple `RenderFragment` lambdas with inline Razor markup in each arm. Builds clean on net10 GA, but on net11 Preview 3 the Razor SG miscompiles and emits 31 errors (CS9348 on every `@inject`, CS0101/CS0102 with empty type/member names, cascading CS0246/CS0426). Wash repro'd it in a clean MAUI Blazor project (PeeThreeRegression) for the upstream issue.
+
+**The fix:** Replace each switch-expression-of-RenderFragment with a tuple-returning meta helper, then inline the markup at the call site:
+
+```csharp
+private static (string CssClass, string IconClass, string Label) GetTypeBadgeMeta(LexicalUnitType type) => type switch
+{
+    LexicalUnitType.Word => ("bg-primary bg-opacity-10 text-primary", "bi-fonts", "Word"),
+    ...
+};
+```
+
+```razor
+@{ var typeMeta = GetTypeBadgeMeta(item.Type); }
+<span class="badge @typeMeta.CssClass"><i class="bi @typeMeta.IconClass me-1"></i>@typeMeta.Label</span>
+```
+
+**Don't do this in Razor again:** switch expression whose arms are `(__builder) => { <markup/> }` lambdas. Pure data tuples + inline markup is safer and cleaner regardless of SG bugs.

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -136,3 +136,20 @@ Zoe's M.E.AI 10.5 strategic recommendations executed via three-agent orchestrati
 
 **SHIP IT verdict**: All validation gates pass; zero regressions introduced. Production-ready.
 
+
+---
+
+## 2026-04-29 — net11p3 Narrative Correction Cycle
+
+Bookkeeping pass to correct earlier overstated framing ("net11p3 broken for our app") with the verified narrow facts: a Razor SG regression on switch-expression-of-RenderFragment-with-inline-markup. Captain's clean `~/work/PeeThreeRegression` MAUI Blazor project builds fine on net11p3 — falsifying the SDK-wide claim. Wash isolated the trigger pattern, packaged a minimal repro (`~/work/peethree-repro-artifacts/peethree-net11p3-repro.zip`), and filed upstream at https://github.com/dotnet/razor/issues/13117. Kaylee refactored the only offending file (`src/SentenceStudio.UI/Pages/ImportContent.razor`) to tuple-meta helpers (`GetTypeBadgeMeta`, `GetStatusBadgeMeta`).
+
+**Bookkeeping actions:**
+1. ✅ decisions.md — added new 2026-04-29T21:00Z entry with corrected facts at top; surgically corrected the 2026-04-29T14:32Z entry's two overreaching conclusions (added pointer to corrected entry, softened the "broken on main" line, added archived-decision references, marked upstream issue filed in follow-ups).
+2. ✅ Moved both inbox decisions (`kaylee-renderfragment-switch-pattern-banned.md`, `wash-net11p3-razor-sg-repro.md`) → `.squad/decisions/archive/`. (Created the archive/ dir — it didn't exist.)
+3. ✅ followups.md — FU-4 reframed and marked RESOLVED with verified path forward (net10 + `-p:ValidateXcodeVersion=false`); kept original framing preserved at end of entry for history.
+4. ✅ store_memory recorded for the trigger pattern + upstream issue.
+
+## Learnings
+
+- **2026-04-29 — When an SDK swap produces a wall of errors, look at error LINE NUMBERS first.** `CS9348` ("compilation unit cannot directly contain members") on `@inject` directive lines (4–10), combined with `CS0101`/`CS0102` with **empty** type/member names, is the fingerprint of a Razor source generator that bailed on the file → it's a pattern-specific bug, NOT an SDK-wide regression. Don't conclude "the SDK is broken" without (a) verifying with a clean `dotnet new` project and (b) isolating the trigger pattern in a minimal repro.
+- **Bookkeeping correction pattern:** when correcting an earlier decisions.md entry whose conclusions overreached, prefer **adding a new dated entry at the top with the corrected facts** + surgically softening the obsolete claims in the original entry (with a forward pointer), over rewriting the original wholesale. Preserves the diagnostic trail; future readers see how the team's understanding evolved.

--- a/.squad/agents/wash/history.md
+++ b/.squad/agents/wash/history.md
@@ -213,3 +213,29 @@ This is the kind of hygiene rule that distinguishes "I think it's broken" from "
 ### Implication
 
 `docs/deploy-runbook.md` Step 2a still needs rewriting (FU-4 owns that task). The replacement is the `-p:ValidateXcodeVersion=false` recipe, NOT a "use cleaner SDK swap" recipe — net11p3 is dead until the upstream Razor regression is fixed.
+
+## Learnings — net11p3 Razor SG repro (2026-04-28)
+
+Confirmed Captain's hypothesis: net11.0.100-preview.3.26209.122 is NOT broadly broken — the regression is pattern-specific. The failing pattern is a **switch expression returning `RenderFragment` lambdas with inline Razor markup**, used inside an `@code` block of a `.razor` file.
+
+### Reproduction recipe
+1. Standard `dotnet new maui-blazor` solution (PeeThreeRegression). Builds clean on net11p3 by default.
+2. Add a single page `Pages/RazorSgRepro.razor` with `@inject NavigationManager Nav` plus a `RenderFragment` switch expression containing inline `<span>` markup in each arm.
+3. `dotnet build PeeThreeRegression.Shared` — fails.
+
+### Diagnostic fingerprint
+- `CS0101: The namespace 'X' already contains a definition for ''` (empty member name)
+- `CS0102: The type 'Y' already contains a definition for ''` (empty member name)
+- Cascading `CS0246` on every type referenced after the switch — including `@inject` services (NavigationManager) and inline-defined enums (SampleType).
+- In files with **multiple** `@inject` directives (like ImportContent.razor in SentenceStudio), this also triggers `CS9348: The compilation unit cannot directly contain members`. The minimal repro only has 1 `@inject`, which is enough to surface CS0246 cascades but not CS9348.
+
+### Root cause hypothesis
+The Razor SG synthesizes private members for each switch arm's RenderFragment but fails to assign them stable identifiers (emits empty `""` names). The duplicate empty names collide → CS0101/CS0102 → entire compilation unit becomes invalid → cascading CS0246 on everything else. CS9348 surfaces when the SG additionally misplaces injected fields at compilation-unit scope.
+
+### Workaround
+Refactor each switch arm to delegate to a separate named `RenderFragment` helper method (single-line `@<span ...>` body). This avoids the inline-markup-inside-switch-arm pattern entirely.
+
+### Artifacts
+- Repro zip: `~/work/peethree-repro-artifacts/peethree-net11p3-repro.zip` (252 KB)
+- Build log: `~/work/peethree-repro-artifacts/peethree-net11p3-repro.log`
+- Both are outside SentenceStudio so they survive any repo cleanup.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -4,7 +4,37 @@
 
 ---
 
-### 2026-04-29T14:32Z: iOS Release Build Recipe Verified — net11p3 Razor Regression Confirmed
+### 2026-04-29T21:00Z: net11p3 Razor SG Regression — Root Cause Identified, Filed Upstream, Workaround Applied
+
+**By:** Scribe (logging team correction cycle)
+**Scope:** Correcting earlier "net11p3 broken" framing with verified narrow regression facts
+
+#### Corrected facts
+
+1. **net11p3 is NOT broadly broken.** Captain verified independently with a clean `dotnet new maui-blazor` project at `~/work/PeeThreeRegression` — it builds and deploys fine on net11 Preview 3 (`11.0.100-preview.3.26209.122`). The earlier "net11p3 broken for our app" framing was wrong.
+
+2. **The regression is narrow and pattern-specific** — a Razor source generator bug on **switch expressions returning `RenderFragment` lambdas with inline Razor markup** (the `(__builder) => { <markup/> }` shape inside `@code` blocks). The SG emits synthetic members with EMPTY names, producing `CS0101`/`CS0102` (duplicate definition with empty name) which then cascades to `CS0246`/`CS9348` on every `@inject` directive in the same file.
+
+3. **Only ONE file in our repo used the pattern:** `src/SentenceStudio.UI/Pages/ImportContent.razor` — two helpers (`RenderTypeBadge`, `RenderStatusBadge`). Kaylee refactored both to **tuple-meta + inline markup** (`GetTypeBadgeMeta`, `GetStatusBadgeMeta` returning `(CssClass, IconClass, Label)`). File shrank 1168→1145 lines, builds clean on net10. Refactor commit pending (separate from this bookkeeping commit).
+
+4. **Wash packaged a clean repro** — minimal ~30-line `.razor` page added to a fresh MAUI Blazor project, reproduces the bug with 4 errors against the Shared library on net11p3. Zipped at `~/work/peethree-repro-artifacts/peethree-net11p3-repro.zip` (252 KB).
+
+5. **Upstream issue filed:** **https://github.com/dotnet/razor/issues/13117** — "[net11p3] Razor SG emits synthetic members with empty names for switch expressions returning RenderFragment lambdas with inline markup".
+
+6. **Production iOS Release recipe (net10 GA + `-p:ValidateXcodeVersion=false`) remains valid and is the recommended path** for the Xcode 26.3 mismatch until the upstream Razor SG fix ships. With ImportContent.razor refactored, the net11p3 SDK swap path is also viable, but unnecessary — there is no longer a forcing function to swap SDKs at all.
+
+#### Archived inbox decisions backing this correction
+
+- `kaylee-renderfragment-switch-pattern-banned.md` → `.squad/decisions/archive/kaylee-renderfragment-switch-pattern-banned.md` — bans the broken pattern repo-wide; documents tuple-meta as preferred replacement.
+- `wash-net11p3-razor-sg-repro.md` → `.squad/decisions/archive/wash-net11p3-razor-sg-repro.md` — verified bug pattern + minimal repro packaged for upstream.
+
+#### Process lesson
+
+When an SDK swap produces a wall of errors, **read the error LINE NUMBERS first** before concluding "SDK is broken." `CS9348` on `@inject` lines (4–10) plus `CS0101`/`CS0102` with **empty** type/member names = the Razor source generator bailed on the file = pattern-specific bug, not a broad SDK regression.
+
+---
+
+### 2026-04-29T14:32Z: iOS Release Build Recipe Verified — net11p3 Narrow Razor SG Regression
 
 **By:** Wash (Backend Dev)  
 **Scope:** Canonical iOS Release build recipe under Xcode 26.3 + .NET SDK mismatch
@@ -32,7 +62,7 @@ Reproduced build with full hygiene:
 4. **Result: 31 errors, 316 warnings, 8.66s.** Identical error count and signatures to Coordinator's first attempt.
 5. Restore `global.json` → confirm net10.
 
-**Conclusion: net11p3 is genuinely incompatible with `ImportContent.razor`.** The contamination hypothesis is FALSE. This is a genuine Razor source-generator regression in the net11 Preview 3 SDK.
+**Conclusion (corrected 2026-04-29T21:00Z):** net11p3 is genuinely incompatible with `ImportContent.razor` **as it was authored** — but this is a **narrow, pattern-specific Razor source-generator regression**, NOT a broad "net11p3 is broken" problem. Captain verified net11p3 builds and deploys a clean `dotnet new maui-blazor` project (`~/work/PeeThreeRegression`) without issue. Wash subsequently isolated the trigger to switch expressions returning `RenderFragment` lambdas with inline Razor markup; Kaylee refactored ImportContent.razor to tuple-meta helpers; upstream issue filed at **https://github.com/dotnet/razor/issues/13117**. The contamination hypothesis was correctly falsified — this entry's _other_ conclusion (an SDK-wide problem) is what was wrong, and is corrected in the 2026-04-29T21:00Z entry above.
 
 **Build log:** `.squad/orchestration-log/2026-04-29-wash-net11p3-clean-build.log`
 
@@ -60,7 +90,7 @@ services__api__https__0=https://api.livelyforest-b32e7d63.centralus.azurecontain
     -p:ValidateXcodeVersion=false
 ```
 
-**Do NOT use the `global.json` net11p3 swap** documented in `docs/deploy-runbook.md` Step 2a. It is broken on main and produces 31 build errors regardless of obj/ hygiene.
+**Recommended:** stay on net10 + `-p:ValidateXcodeVersion=false`. The `global.json` net11p3 swap documented in `docs/deploy-runbook.md` Step 2a is no longer necessary — with the ImportContent.razor refactor (Kaylee, 2026-04-29) the swap would now succeed, but the net10 + flag path is simpler and recommended until the upstream Razor SG fix (dotnet/razor#13117) ships.
 
 #### New Process Rule
 
@@ -75,7 +105,8 @@ find <project-dirs> -name bin -type d -exec rm -rf {} +
 
 - ✅ FU-4 in `.squad/followups.md` updated with verified facts.
 - 🔄 `docs/deploy-runbook.md` Step 2a rewrite remains a separate task (not done here).
-- 🔄 Captain to decide whether to file upstream Razor SDK bug for net11 Preview 3.
+- ✅ Upstream Razor SDK bug filed: https://github.com/dotnet/razor/issues/13117 (2026-04-29).
+- ✅ ImportContent.razor refactored to tuple-meta + inline markup (Kaylee, 2026-04-29).
 
 ---
 

--- a/.squad/decisions/archive/kaylee-renderfragment-switch-pattern-banned.md
+++ b/.squad/decisions/archive/kaylee-renderfragment-switch-pattern-banned.md
@@ -1,0 +1,82 @@
+# Decision: Ban switch-expression-returning-RenderFragment-with-inline-markup in Razor
+
+**Author:** Kaylee
+**Status:** Proposed (inbox)
+**Date:** 2025
+
+## Context
+
+While preparing for the .NET 11 Preview 3 SDK swap (used during iOS device publish to DX24), Captain hit a catastrophic build failure in `src/SentenceStudio.UI/Pages/ImportContent.razor` — 31 errors including CS9348 on every `@inject` and CS0101/CS0102 with empty type/member names. The same file builds clean on net10 GA.
+
+Wash isolated the trigger to a single Razor pattern in that file, and reproduced the regression in a fresh MAUI Blazor project (`PeeThreeRegression`) for an upstream dotnet/razor issue.
+
+## The banned pattern
+
+```csharp
+private static RenderFragment RenderTypeBadge(LexicalUnitType type) => type switch
+{
+    LexicalUnitType.Word => (__builder) =>
+    {
+        <span class="badge bg-primary"><i class="bi bi-fonts me-1"></i>Word</span>
+    },
+    LexicalUnitType.Phrase => (__builder) =>
+    {
+        <span class="badge bg-secondary"><i class="bi bi-chat-quote me-1"></i>Phrase</span>
+    },
+    ...
+};
+```
+
+A C# **switch expression** whose arms are `RenderFragment` lambdas (`(__builder) => { ... }`) with **inline Razor markup** inside each arm. The Razor SG in net11p3 miscompiles this into a malformed partial class.
+
+## Decision
+
+**Don't use this pattern.** Prefer one of:
+
+### Preferred: tuple-meta + inline markup (Option A)
+
+```csharp
+private static (string CssClass, string IconClass, string Label) GetTypeBadgeMeta(LexicalUnitType type) => type switch
+{
+    LexicalUnitType.Word => ("bg-primary bg-opacity-10 text-primary", "bi-fonts", "Word"),
+    LexicalUnitType.Phrase => ("bg-secondary bg-opacity-10 text-secondary", "bi-chat-quote", "Phrase"),
+    ...
+};
+```
+
+```razor
+@{ var typeMeta = GetTypeBadgeMeta(item.Type); }
+<span class="badge @typeMeta.CssClass"><i class="bi @typeMeta.IconClass me-1"></i>@typeMeta.Label</span>
+```
+
+Pros: no SG indirection, smaller diff, easier to localize/style, cleaner DOM authorship.
+
+### Acceptable fallback: single RenderFragment with parameter (Option B)
+
+If markup is genuinely complex and you must extract it, write **one** `RenderFragment` parameterized by the meta tuple — not a switch expression of multiple RenderFragment arms:
+
+```csharp
+private static RenderFragment RenderBadge((string CssClass, string IconClass, string Label) meta) => __builder =>
+{
+    <span class="badge @meta.CssClass"><i class="bi @meta.IconClass me-1"></i>@meta.Label</span>
+};
+```
+
+The single-arm shape doesn't trip the SG bug.
+
+## Rationale
+
+1. **Avoids the net11p3 regression** entirely. We swap to the net11p3 SDK during iOS device publish — any file with this pattern blocks the publish.
+2. **Cleaner separation of data vs. markup.** Tuple meta is trivially testable; the markup stays where Razor expects markup.
+3. **No measurable runtime cost.** Both shapes lower to roughly equivalent IL after the SG processes them.
+
+## Scope
+
+Applies to all `.razor` files under `src/SentenceStudio.UI/`. Files reviewed in this pass:
+- `src/SentenceStudio.UI/Pages/ImportContent.razor` (refactored — was the only offender)
+
+## Action items
+
+- [x] Refactor `ImportContent.razor` (done)
+- [ ] When net11p3 SDK is the daily driver, sweep the rest of the .razor files for any new instances and refactor proactively.
+- [ ] Mention in the iOS publish runbook (`docs/deploy-runbook.md`) that this pattern blocks the SDK swap, so future Razor authors get the heads-up.

--- a/.squad/decisions/archive/wash-net11p3-razor-sg-repro.md
+++ b/.squad/decisions/archive/wash-net11p3-razor-sg-repro.md
@@ -1,0 +1,64 @@
+# Decision: net11 Preview 3 Razor SG regression — verified bug pattern + repro available
+
+**Author:** Wash (Backend Dev)
+**Date:** 2026-04-28
+**Status:** Verified, repro packaged, ready to file upstream
+
+## Context
+SentenceStudio's `src/SentenceStudio.UI/Pages/ImportContent.razor` fails to compile under .NET 11 Preview 3 (`11.0.100-preview.3.26209.122`) with 31 errors per build. The same file compiles cleanly on .NET 10 GA. Captain hypothesized the regression was pattern-specific rather than SDK-wide. Verified.
+
+## Decision
+File a bug against `dotnet/razor` (or `dotnet/sdk` if Razor team redirects) using the minimal MAUI Blazor repro I built.
+
+## The pattern that breaks
+A switch expression returning `RenderFragment` where each arm contains an inline `(__builder) => { ... }` lambda with **Razor markup** inside the lambda body, declared inside an `@code` block in a `.razor` file.
+
+```razor
+@code {
+    private static RenderFragment RenderBadge(SampleType type) => type switch
+    {
+        SampleType.Alpha => (__builder) => { <span>Alpha</span> },
+        SampleType.Beta  => (__builder) => { <span>Beta</span> },
+        _                => (__builder) => { <span>Unknown</span> }
+    };
+}
+```
+
+## Diagnostic fingerprint
+- `CS0101` with **empty** member name
+- `CS0102` with **empty** member name
+- Cascading `CS0246` on every type after the switch (including `@inject` services and inline enums)
+- `CS9348` ("compilation unit cannot directly contain members") when ≥1 `@inject` is present alongside the broken pattern — the SG appears to drop injected fields at file scope after the switch fails to emit valid member names
+
+## Verified
+- **Works:** .NET 10 GA — original SentenceStudio code path
+- **Fails:** .NET 11 Preview 3 (`11.0.100-preview.3.26209.122`)
+- **Repro project:** PeeThreeRegression (clean `dotnet new maui-blazor`) + 1 added Razor page reproduces 4 errors in the Shared library
+
+## Artifacts
+- **Repro zip:** `~/work/peethree-repro-artifacts/peethree-net11p3-repro.zip` (252 KB) — attach to GitHub issue
+- **Build log:** `~/work/peethree-repro-artifacts/peethree-net11p3-repro.log` — paste excerpt into issue body
+- **Repro file inside zip:** `peethree-net11p3-repro/PeeThreeRegression.Shared/Pages/RazorSgRepro.razor`
+- **REPRO.md** at zip root explains pattern, SDKs, expected/actual, steps, workaround
+
+## Recommended SentenceStudio mitigation (until upstream fixes the SG)
+For any `.razor` file using the broken pattern, refactor each switch arm to invoke a separately declared `RenderFragment` helper method instead of using inline markup. Single-line helpers using the `@<span ...>` shorthand work fine:
+
+```csharp
+private static RenderFragment RenderAlpha() => @<span class="badge bg-primary">Alpha</span>;
+```
+
+This is the immediate path to letting Captain run net11p3 SDK in this repo. Kaylee is refactoring `ImportContent.razor` along these lines in parallel — this decision documents the bug she's working around.
+
+## Where to file
+- Primary: https://github.com/dotnet/razor/issues
+- If redirected: https://github.com/dotnet/sdk/issues
+
+## What to include in the issue body
+1. Title: "Razor SG: switch expression returning inline-markup `RenderFragment` lambdas emits members with empty names (net11 Preview 3 regression)"
+2. Repro project zip attached
+3. The pattern (above)
+4. Diagnostic fingerprint (above)
+5. SDK info: works on net10 GA, fails on `11.0.100-preview.3.26209.122`
+6. Steps: install net11p3 SDK → `dotnet build` the Shared csproj → 4 errors with empty names
+7. Workaround (above)

--- a/.squad/followups.md
+++ b/.squad/followups.md
@@ -83,49 +83,26 @@ Not critical for .NET 10 GA release; QoL improvement for future SDK updates.
 ---
 
 
-## FU-4: Rewrite `docs/deploy-runbook.md` Step 2a — drop net11p3 global.json swap
+## FU-4: ~~Rewrite `docs/deploy-runbook.md` Step 2a — drop net11p3 global.json swap~~
 
-**Status:** Discovered 2026-04-29 (import-content production deploy); **VERIFIED 2026-04-29 by Wash (clean obj/bin rebuild)**  
-**Severity:** Medium (runbook actively misleading; first-time deployer following it will hit 31 build errors)  
+**Status:** ✅ RESOLVED 2026-04-29T21:00Z (root cause identified, filed upstream, workaround applied)
+**Severity:** Was Medium; now informational
 **Scope:** `docs/deploy-runbook.md` Step 2a — iOS Release build instructions
 
-### Problem
+### Resolution summary
 
-Step 2a tells the operator to swap `global.json` to `11.0.100-preview.3.26209.122` (net11 Preview 3) before building iOS Release, then restore net10 after. This was the workaround for Xcode 26.3 vs net10 GA SDK mismatch.
+Earlier framing (below) treated this as "net11p3 broken on main, runbook actively misleading." **That framing was wrong.** Corrected facts:
 
-It is now broken: **the net11p3 Razor SDK genuinely cannot compile `src/SentenceStudio.UI/Pages/ImportContent.razor` and produces 31 errors.** The import-content feature is in main, so anyone following the runbook will fail.
+1. **net11p3 is not broadly broken.** Captain verified with a clean `dotnet new maui-blazor` project at `~/work/PeeThreeRegression` — builds and deploys fine.
+2. **Narrow Razor SG regression** — switch expressions returning `RenderFragment` lambdas with inline Razor markup; SG emits synthetic members with empty names → CS0101/CS0102, cascading CS0246/CS9348 on `@inject` lines.
+3. **Filed upstream:** https://github.com/dotnet/razor/issues/13117 (Wash, 2026-04-29) — repro zip: `~/work/peethree-repro-artifacts/peethree-net11p3-repro.zip` (252 KB).
+4. **The only file in the repo that triggered the bug was `src/SentenceStudio.UI/Pages/ImportContent.razor`.** Kaylee refactored it (2026-04-29) — replaced two `RenderTypeBadge`/`RenderStatusBadge` switch-expression-of-RenderFragment helpers with tuple-meta helpers (`GetTypeBadgeMeta`, `GetStatusBadgeMeta`) returning `(CssClass, IconClass, Label)` consumed inline.
+5. **Net result:** Step 2a (the `global.json` swap to net11p3 for iOS device publish) **is no longer needed** for SentenceStudio because (a) we use **net10 + `-p:ValidateXcodeVersion=false`** as the canonical iOS Release recipe, AND (b) the only file that triggered the bug has been refactored, so the swap path would also succeed if anyone needed it.
+6. **Hygiene rule still valid:** if you ever swap SDKs via `global.json`, wipe `obj/` AND `bin/` first — `dotnet clean` is not sufficient.
 
-### Verification (2026-04-29, Wash)
+### Verified path forward
 
-Captain suspected the 31-error report might be obj/ contamination from the prior net10 build (Coordinator did NOT `dotnet clean` between SDK swaps). Wash re-ran with proper hygiene:
-
-1. Backup global.json → swap to net11p3 → confirm `dotnet --version` = `11.0.100-preview.3.26209.122`
-2. **Wipe `obj/` and `bin/` from `src/SentenceStudio.UI/` and `src/SentenceStudio.iOS/`** (full nuke, not just `dotnet clean`)
-3. Build iOS Release: same command as runbook Step 2a
-4. **Result: 31 errors, 316 warnings, 8.66s.** Identical error count and identical error signatures to Coordinator's first attempt.
-5. Restore global.json → confirm net10.
-
-**Conclusion: net11p3 is genuinely incompatible with `ImportContent.razor`.** The contamination hypothesis is FALSE. Build log: `.squad/orchestration-log/2026-04-29-wash-net11p3-clean-build.log`.
-
-### Verified error signatures (sampled from clean rebuild)
-
-```
-ImportContent.razor(4,9): error CS0246: type 'IContentImportService' could not be found
-ImportContent.razor(5,9): error CS0246: type 'LearningResourceRepository' could not be found
-ImportContent.razor(7,9): error CS0246: type 'NavigationManager' could not be found
-ImportContent.razor(9,9): error CS0246: type 'ILogger<>' could not be found
-ImportContent.razor(4,31): error CS9348: A compilation unit cannot directly contain members
-ImportContent.razor(1124,79): error CS0102: type 'ImportContent' already contains a definition for ''
-ImportContent.razor(1128,83): error CS0101: namespace 'SentenceStudio.WebUI.Pages' already contains a definition for ''
-ImportContent.razor(1126,25): error CS0426: type name 'Phrase' does not exist in 'LexicalUnitType'
-ImportContent.razor(11,13): error CS0535: 'ImportContent' does not implement 'IDisposable.Dispose()'
-```
-
-The CS9348 / CS0246 cluster on `@inject` directive lines (4–10) plus the duplicate-definition CS0101/CS0102 with empty type/member names is a Razor source generator regression in the net11p3 Razor SDK — `@inject` directives are being parsed as raw C# instead of being lifted into the generated component partial class.
-
-### Correct Recipe (verified 2026-04-29 deploy + Wash re-verification)
-
-Stay on net10 GA SDK (`10.0.101`); pass `-p:ValidateXcodeVersion=false` to skip the Xcode 26.3 version assertion:
+**Canonical iOS Release recipe** (no SDK swap needed):
 
 ```bash
 services__api__https__0=https://api.livelyforest-b32e7d63.centralus.azurecontainerapps.io \
@@ -135,22 +112,25 @@ services__api__https__0=https://api.livelyforest-b32e7d63.centralus.azurecontain
     -p:ValidateXcodeVersion=false
 ```
 
-This is now the **canonical** iOS Release recipe.
+### Required edits to deploy-runbook.md (still a separate task)
 
-### Required Edits to deploy-runbook.md (separate task — DO NOT do here)
-
-1. Step 2a: remove the `cp global.json global.json.bak` / net11p3 swap / restore dance entirely
-2. Document `-p:ValidateXcodeVersion=false` as the standard flag for the Xcode 26.3 mismatch
-3. Update top-of-file "## .NET SDK Selection in This Repo" notes if they reference the swap; note that the swap is **broken on main** until the Razor SDK regression is resolved upstream
-4. Add a hygiene rule: **if you ever do swap SDKs via `global.json`, always wipe `obj/` and `bin/` first** — `dotnet clean` is not sufficient because Razor source-gen artifacts can collide
-5. Verify `global.json.bak` handling in `.gitignore`
+1. Step 2a: remove the `cp global.json global.json.bak` / net11p3 swap / restore dance.
+2. Document `-p:ValidateXcodeVersion=false` as the standard flag for the Xcode 26.3 mismatch.
+3. Update top-of-file ".NET SDK Selection" notes to reflect that the swap is **optional** (not broken) and only relevant if upstream guidance changes.
+4. Add the obj/bin wipe hygiene rule.
+5. Reference the upstream issue (https://github.com/dotnet/razor/issues/13117) so future readers understand the historical context.
 
 ### Cross-refs
 
+- **Upstream issue:** https://github.com/dotnet/razor/issues/13117
+- **Corrected decision:** `.squad/decisions.md` — 2026-04-29T21:00Z entry (and corrections to 2026-04-29T14:32Z entry)
+- **Archived decisions:** `.squad/decisions/archive/kaylee-renderfragment-switch-pattern-banned.md`, `.squad/decisions/archive/wash-net11p3-razor-sg-repro.md`
+- **Repro artifacts:** `~/work/peethree-repro-artifacts/peethree-net11p3-repro.zip`
 - Orchestration log: `.squad/orchestration-log/2026-04-29T014444Z-publish-import-content.md`
 - Wash verification log: `.squad/orchestration-log/2026-04-29-wash-net11p3-clean-build.log`
-- Decision drop: `.squad/decisions/inbox/wash-ios-build-recipe-verified.md`
-- Decision: `.squad/decisions.md` — 2026-04-29T01:44Z entry
-- Agent history: `.squad/agents/kaylee/history.md` Learnings (2026-04-29); `.squad/agents/wash/history.md` (2026-04-29 entry)
+
+### Original entry (preserved for history)
+
+The original framing called this "net11p3 broken on main, runbook actively misleading; first-time deployer following it will hit 31 build errors." That was technically true at the time the entry was written, but the framing missed the narrowness of the regression. Wash's clean rebuild correctly falsified the obj/-contamination hypothesis but stopped short of isolating the trigger pattern; the team did that next, and Captain's clean `PeeThreeRegression` project provided the counter-evidence that net11p3 itself is fine.
 
 ---

--- a/src/SentenceStudio.Shared/Models/FilterToken.cs
+++ b/src/SentenceStudio.Shared/Models/FilterToken.cs
@@ -10,7 +10,8 @@ public sealed record FilterToken(string Type, string Value)
         "status",
         "association",
         "language",
-        "encoding"
+        "encoding",
+        "type"
     };
 
     public bool IsValid =>

--- a/src/SentenceStudio.Shared/Services/SearchQueryParser.cs
+++ b/src/SentenceStudio.Shared/Services/SearchQueryParser.cs
@@ -19,7 +19,7 @@ public class SearchQueryParser : ISearchQueryParser
     // Supports quoted values for multi-word filters: tag:"multi word"
     // Also supports unquoted values that end at whitespace
     private static readonly Regex FilterPattern = new(
-        @"(tag|resource|lemma|status|association|language|encoding):(?:""([^""]*)""|(\S+))",
+        @"(tag|resource|lemma|status|association|language|encoding|type):(?:""([^""]*)""|(\S+))",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     /// <summary>
@@ -128,7 +128,7 @@ public class SearchQueryParser : ISearchQueryParser
         var textBeforeCursor = text.Substring(0, cursorPosition);
 
         // Match filter prefix at end of text: tag:partial or tag:"partial
-        var activeFilterPattern = new Regex(@"(tag|resource|lemma|status|association|language|encoding):(?:""([^""]*)|(\S*))$", RegexOptions.IgnoreCase);
+        var activeFilterPattern = new Regex(@"(tag|resource|lemma|status|association|language|encoding|type):(?:""([^""]*)|(\S*))$", RegexOptions.IgnoreCase);
         var match = activeFilterPattern.Match(textBeforeCursor);
 
         if (match.Success)

--- a/tests/SentenceStudio.UnitTests/Services/SearchQueryParserTests.cs
+++ b/tests/SentenceStudio.UnitTests/Services/SearchQueryParserTests.cs
@@ -125,6 +125,36 @@ public class SearchQueryParserTests
         result.Filters[0].Value.Should().Be("learning");
     }
 
+    // Regression for issue #179: type: filter token was missing from parser regex,
+    // causing type:Sentence to fall through to free text and silently produce no results.
+    [Theory]
+    [InlineData("type:Word", "Word")]
+    [InlineData("type:Phrase", "Phrase")]
+    [InlineData("type:Sentence", "Sentence")]
+    [InlineData("type:WORD", "WORD")]
+    [InlineData("type:phrase", "phrase")]
+    public void Parse_TypeFilter_ExtractsCorrectly(string query, string expectedValue)
+    {
+        var result = _sut.Parse(query);
+
+        result.Filters.Should().HaveCount(1);
+        result.Filters[0].Type.Should().Be("type");
+        result.Filters[0].Value.Should().Be(expectedValue);
+        result.FreeTextTerms.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_TypeFilterCombinedWithResource_ExtractsBoth()
+    {
+        // Mirrors the original failing URL from issue #179.
+        var result = _sut.Parse("resource:\"Olivia 쌤\" type:Sentence");
+
+        result.Filters.Should().HaveCount(2);
+        result.Filters.Should().ContainSingle(f => f.Type == "resource" && f.Value == "Olivia 쌤");
+        result.Filters.Should().ContainSingle(f => f.Type == "type" && f.Value == "Sentence");
+        result.FreeTextTerms.Should().BeEmpty();
+    }
+
     [Fact]
     public void Parse_FreeTextOnly_ExtractsTerms()
     {


### PR DESCRIPTION
Fixes #179

## Problem
Vocabulary page added a `type:` dropdown filter for Word/Phrase/Sentence, but `SearchQueryParser` regex never whitelisted the `type` token. So `type:Sentence` fell through to free text and silently produced 0 results.

Original failing URL: `/vocabulary?q=resource:"Olivia 쌤" type:Sentence`

## Fix
Three lines:
- Add `"type"` to `FilterToken.ValidTypes`
- Add `|type` to `FilterPattern` regex
- Add `|type` to `DetectActiveFilter` regex

## Tests
Added 6 regression tests in `SearchQueryParserTests`:
- `Parse_TypeFilter_ExtractsCorrectly` — Theory across Word/Phrase/Sentence (incl. case variants)
- `Parse_TypeFilterCombinedWithResource_ExtractsBoth` — exact failing URL from #179

All 59 parser tests pass.

## E2E validation
Verified on running webapp:
- `type:Word` → 246 of 273 (chip rendered)
- `type:Sentence` → 21 of 273 (chip rendered)
- `type:Phrase` → 6 of 273 (chip rendered)
- 246 + 21 + 6 = 273 ✓

## Out of scope
Sentences smart resource + ResourceEdit read-only mode will land as a follow-up PR — keeping this one tight.
