### PR TITLE
fix(sync): self-repair tainted VocabularyProgress rows from CoreSync corruption event

### DIFF
--- a/.squad/agents/troubleshooter/history.md
+++ b/.squad/agents/troubleshooter/history.md
@@ -1,0 +1,78 @@
+# Troubleshooter — History & Learnings
+
+## Learnings
+
+### 2026-05-01 — CoreSync VocabularyProgress sync failure (Postgres 42804)
+
+- **Symptom Captain reported:** Quiz activity failed to start with "some data error" + Mac Catalyst app unresponsive after a few navigations on `feature/dashboard-vocab-tile-nav` (PR #184).
+- **Where the evidence lived:** Aspire structured logs were initially invisible because `aspire-list_structured_logs` defaulted to `SentenceStudio.Workers` (chatty `HttpMessageHandler` debug logs filled the 76-entry size cap). Passing `resourceName: "SentenceStudio.Api"` (the OTLP service name, NOT the dashboard resource id `api-edufvexh`) surfaced 11 errors immediately. **Lesson:** the Aspire dashboard `resource_name` (e.g. `api-edufvexh`) is NOT the same as the OTLP `resource_name` attribute (e.g. `SentenceStudio.Api`). For `aspire-list_structured_logs` use the OTLP service name. For `aspire-list_console_logs` use the dashboard resource id.
+- **Pulling full exception text:** When the structured-logs payload truncates to "Duplicate of exception for log entry NNN", use `aspire-list_trace_structured_logs` with the trace_id from any of the duplicates — that returns the original entry with full exception/stack.
+- **Root cause (verbatim Postgres error):**
+  ```
+  CoreSync.SynchronizationException: Unable to Insert item Insert on VocabularyProgress: {... "UserDeclaredAt": "UserDeclaredAt", "VerificationState": "VerificationState" ...} 42804: column "UserDeclaredAt" is of type timestamp with time zone but expression is of type text
+  ```
+  CoreSync's change-set dictionary literally contains the **column NAME as the value** for both `UserDeclaredAt` (DateTime?) and `VerificationState` (int enum). The Postgres provider then sends `'UserDeclaredAt'` as a text literal into a `timestamp with time zone` column → 42804 type mismatch.
+- **Hypothesis on the CoreSync bug:** the SQLite change-tracking trigger or the column extraction for these two columns is mis-generated — likely because they were added in a later EF migration and CoreSync's provisioning didn't re-derive triggers. Repro is deterministic: same batch GUID `1c18d82b-d160-424d-9ecf-bec51d04ba1e` re-fails on every retry (RequestIds EF→F0→F1 incremented on each retry).
+- **Mac Catalyst hang:** Process 71568 was `S` state, 0% CPU — kernel-level idle. Sync failures themselves are caught & released the semaphore (SyncService.cs:326-340), so sync doesn't block. Hang is therefore **independent or downstream** — most likely a Blazor WebView modal/dialog from the data-error toast that's not getting dismissed cleanly, or a JS interop deadlock after the failed sync chain. Without `maui devflow` connected (broker daemon TCP listener not reachable), can't introspect further.
+- **Relationship to PR #184:** ZERO. PR #184 only touches Vocabulary.razor filter switch (client-side LINQ on already-loaded data) and Index.razor anchor wrappers. Does not touch sync, EF models, VocabularyProgress, or any write path. Bug pre-dates this branch.
+
+### Diagnostic playbook for "some data error" in this app
+1. `aspire-list_structured_logs resourceName:"SentenceStudio.Api"` — filter for severity Error/Warning.
+2. If exception text shows "Duplicate of … for log entry NNN", call `aspire-list_trace_structured_logs traceId:<from any dup>` to recover the original.
+3. Sync failures appear as `CoreSync.SynchronizationException` on `/api/sync-agent/changes-bulk-complete/{guid}`. The batch GUID is constant across retries — useful to confirm "stuck batch" pattern.
+4. Recurring sync failures don't kill the process but DO accumulate retry pressure; a UI that awaits sync completion (or prompts an error dialog) can leave the app feeling unresponsive even though the process is healthy.
+
+---
+
+## Round 2 — VocabularyProgress data corruption deep-dive (2026-05-01)
+
+**Context:** Followed up Round 1's `42804` upload bug after Captain reported a new toast on the Vocabulary page: *"Error loading vocabulary: The string 'UserDeclaredAt' was not recognized as a valid DateTime."* This is the same bug surfacing through the EF read path instead of the CoreSync upload path.
+
+### Key new evidence
+
+- **Live DB inspection** at `~/Library/Containers/C5750C50-.../Data/Library/sstudio.db3` (copied to `/tmp/sstudio.db3` for `sqlite3` access — sandbox locks the parent dir): **all 1745 `VocabularyProgress` rows** have `UserDeclaredAt='UserDeclaredAt'`, `VerificationState='VerificationState'`, `IsUserDeclared='IsUserDeclared'` — the column NAME stored as a literal text VALUE.
+- Schema itself is clean (`InitialSqlite` migration is correct; later ALTER TABLE columns `LastExposedAt`/`ExposureCount` are unrelated).
+- EF Core's `DateTime?` materializer calls `DateTime.Parse("UserDeclaredAt", ...)` → `FormatException` at `VocabularyProgressRepository.GetAllForUserAsync` (line 111-114), caught by `Vocabulary.razor` LoadData's try/catch and shown via toast.
+
+### Where the corruption did **not** come from (verified)
+
+- No EF migration ever wrote a column-name literal as a default — `20260307234624_AddFamiliarStatusAndVerification.cs` (the original) and `20260321133148_InitialSqlite.cs` both use clean `defaultValue: false / 0`.
+- `SyncService.PatchMissingColumnsAsync` does not — and per `git log -S` has never — patch `UserDeclaredAt`/`VerificationState`/`IsUserDeclared`.
+- Full-repo grep for the column-name string literals (excluding `Migrations/`, `obj/`, `bin/`) returns zero matches in app code, current or historical.
+- CoreSync `0.1.128-local` package is just a metadata-only re-stamp of `0.1.127` (assembly version differs, **decompiled bodies are byte-identical** — verified with `diff`). Don't waste time chasing it as a separate version.
+- CoreSync.Sqlite issues no `ALTER TABLE` against user tables in any decompiled version (122/127/128-local).
+
+### Where the corruption probably came from
+
+Static analysis of all CoreSync versions on Captain's machine doesn't reveal a reproducible "writes column-name as value" path. The corruption is most likely a **one-time event** — perhaps a previous CoreSync release pre-0.1.122, a manual SQLite UPDATE, or an aborted EF migration mid-March. Captain's machine is the only known carrier; there's no evidence in our git history that we ever shipped a build that produces this. **Don't keep chasing the producer** — fix the data and harden the read/sync path.
+
+### Three latent CoreSync defects that turn local corruption into a multi-surface failure
+
+1. **`CoreSync.Sqlite.GetValueFromRecord(SqliteDataReader, int, Type)`** (~line 939, same shape in `CoreSync.PostgreSQL` ~line 1064) — type dispatch handles only the unwrapped primitives. `Nullable<T>` and `enum` fall through to `r.GetValue(ord)`, which returns the raw text for SQLite TEXT columns. Combined with **(3)**, the value silently becomes a `string` on the wire.
+2. **`CoreSync.PostgreSQL.ConvertValueForColumn`** (~line 1576) — when the source value is `string` and the column is `timestamptz`, it calls `DateTime.TryParse`; on failure it **passes the unparsed string straight through to the INSERT**, so the database engine is the only thing that catches the type mismatch (Postgres `42804`). A defensive provider would fail-fast with a clear "type mismatch" error.
+3. **`CoreSync.SyncItemValue.DetectTypeOfObject`** (~`CoreSync` line 780) — pure runtime-type switch. Once a value has been silently demoted to `string` by (1), it gets serialized as `SyncItemValueType.String` with no schema check.
+
+These are upstream defects to **track**, not patch in our tree without Coordinator approval (per Captain's standing rule).
+
+### Recommended workaround (in our repo only)
+
+Add a `RepairTaintedVocabularyProgressAsync` helper to `SyncService.cs`, called from `PatchMissingColumnsAsync` before `MigrateAsync()` — does an idempotent `UPDATE` that resets the three known tainted columns to safe defaults. Full code + safety justifications are in `.squad/decisions/inbox/troubleshooter-coresync-vocabprogress-userdeclaredat.md` under "Round 2".
+
+### Test plan (per Captain's "if it came back, it needs a test" rule)
+
+- Unit test for the repair helper itself (clean row untouched, fully-tainted row reset, partially-tainted row partial-reset, idempotent on second call).
+- EF round-trip integration test (insert NULL/0/0, materialize without `FormatException`, mutate, save, reload).
+- Optional CoreSync regression test (round-trip a tainted SyncItem through SqliteSyncProvider→PostgreSQLSyncProvider, expect type-aware rejection rather than `42804`).
+
+### Diagnostic playbook updates (additions to round-1 playbook)
+
+- `ilspycmd` 9.1.0.7988 from dotnet 8 won't run on the local SDK 10 by default — set `DOTNET_ROLL_FORWARD=LatestMajor` before invoking. **Always pre-decompile all installed versions** of the suspect package (`~/.nuget/packages/<pkg>/<ver>/lib/<tfm>/...dll`) and `diff` them; "local" version stamps may be metadata-only re-stamps.
+- For sandboxed Mac Catalyst databases, `cp` to `/tmp` (not `mv`) before `sqlite3` opens — the original parent dir is locked while the app is running, but read copies are fine.
+- `git log -S '<column-name>' -- <file>` is much faster than reading every historical revision when answering "did this code ever contain this string?" — use it before doing a `git show` walk.
+- When EF materialization throws an opaque-looking exception, **reproduce by running the same `Where` clause manually in `sqlite3` and inspect the suspect column's distinct values** (`SELECT col, COUNT(*) FROM tbl GROUP BY col`) — type-mismatch corruption is usually visible in one query.
+
+### What I deliberately did **not** do
+
+- Did not kill PID 99325 or modify Captain's live DB (per standing order — Captain's Mac is production).
+- Did not open any upstream issue against CoreSync (per standing order).
+- Did not commit any code changes — round 2 was read-only investigation as instructed.

--- a/docs/captain-runbook-vocabprogress-repair.md
+++ b/docs/captain-runbook-vocabprogress-repair.md
@@ -1,0 +1,62 @@
+# Captain Runbook — Repair tainted VocabularyProgress rows on this Mac
+
+**When:** Run this once, manually, when you're back at the keyboard.
+**Why:** All 1745 rows of `VocabularyProgress` in your local Mac Catalyst SQLite have literal column NAMES stored as values (`UserDeclaredAt='UserDeclaredAt'`, etc.). EF can't `DateTime.Parse('UserDeclaredAt')`, so every vocab page on Mac Catalyst raises a toast and fails.
+
+This runbook is the **immediate unblock** so you can keep using your Mac Catalyst app today. The permanent code-side guard ships in a separate PR.
+
+## Step 1 — Quit the Mac Catalyst app
+
+Cmd-Q SentenceStudio from the Dock. The DB must be closed before mutating it.
+
+```bash
+ps -ef | grep -i sentencestudio | grep -v grep
+# If you see a SentenceStudio process, quit it from the Dock first.
+```
+
+## Step 2 — Back up the DB
+
+```bash
+DB="$HOME/Library/Containers/C5750C50-4CF5-448D-8B79-E5695B8EE653/Data/Library/sstudio.db3"
+cp -a "$DB" "$DB.bak-$(date +%Y%m%d-%H%M%S)"
+ls -la "$DB"*
+```
+
+## Step 3 — Verify the taint count (read-only)
+
+```bash
+sqlite3 "$DB" "SELECT COUNT(*) AS tainted FROM VocabularyProgress WHERE UserDeclaredAt = 'UserDeclaredAt';"
+# Expected: 1745
+```
+
+## Step 4 — Run the repair (idempotent)
+
+```bash
+sqlite3 "$DB" <<SQL
+UPDATE VocabularyProgress SET UserDeclaredAt    = NULL WHERE UserDeclaredAt    = 'UserDeclaredAt';
+UPDATE VocabularyProgress SET VerificationState = 0    WHERE VerificationState = 'VerificationState';
+UPDATE VocabularyProgress SET IsUserDeclared    = 0    WHERE IsUserDeclared    = 'IsUserDeclared';
+SELECT 'after', COUNT(*) AS still_tainted_userdec
+FROM VocabularyProgress WHERE UserDeclaredAt = 'UserDeclaredAt';
+SQL
+# Expected last line: after|0
+```
+
+## Step 5 — Relaunch the app and verify
+
+- Open the Mac Catalyst app.
+- Navigate to Vocabulary. **No toast.**
+- Try the Vocab Quiz. **Should launch.**
+- Watch the Aspire `SentenceStudio.Api` logs for sync uploads — the stuck batch `1c18d82b-d160-424d-9ecf-bec51d04ba1e` should NOT recur.
+
+## If something goes wrong
+
+Restore from the backup created in Step 2:
+
+```bash
+cp -a "$DB.bak-<timestamp>" "$DB"
+```
+
+## Permanent fix
+
+A separate PR adds `RepairTaintedVocabularyProgressAsync` to `SyncService.cs` that runs this same repair automatically on app startup before `MigrateAsync`, so any other client that ever picks up tainted rows from sync self-heals. See the PR for details.

--- a/src/SentenceStudio.Shared/SentenceStudio.Shared.csproj
+++ b/src/SentenceStudio.Shared/SentenceStudio.Shared.csproj
@@ -7,6 +7,13 @@
 		<PublishSelfContained>false</PublishSelfContained>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<!-- Expose internal helpers (e.g. SyncService.RepairTaintedVocabularyProgressAsync)
+		     to the unit-test project so we can write regression tests without widening
+		     the public API surface. -->
+		<InternalsVisibleTo Include="SentenceStudio.UnitTests" />
+	</ItemGroup>
+
 	<!-- ASP.NET Core Identity: server-only (no iOS/Android runtime pack) -->
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/SentenceStudio.Shared/Services/SyncService.cs
+++ b/src/SentenceStudio.Shared/Services/SyncService.cs
@@ -515,6 +515,12 @@ public class SyncService : ISyncService
             }
         }
 
+        // Defensive self-repair for one-time CoreSync corruption event that left
+        // literal column-name strings in VocabularyProgress rows. Runs BEFORE
+        // ReconcileMigrationHistoryAsync / MigrateAsync so EF never tries to
+        // materialize a tainted DateTime?/enum value and throw FormatException.
+        await RepairTaintedVocabularyProgressAsync(conn);
+
         // Reconcile __EFMigrationsHistory against actual DB schema.
         // For each known migration whose artifacts are already present in the DB
         // (either from a previous release or from our defensive patches above),
@@ -629,5 +635,120 @@ public class SyncService : ISyncService
     }
 #endif
 
+    /// <summary>
+    /// Defensive self-repair for tainted <c>VocabularyProgress</c> rows.
+    ///
+    /// Background: a one-time CoreSync corruption event (root cause not reproducible
+    /// from any current code path — see decision doc below) left every row in
+    /// <c>VocabularyProgress</c> on at least one Mac Catalyst client with the literal
+    /// column NAME stored as a value:
+    /// <c>UserDeclaredAt = 'UserDeclaredAt'</c>,
+    /// <c>VerificationState = 'VerificationState'</c>,
+    /// <c>IsUserDeclared = 'IsUserDeclared'</c>.
+    /// SQLite's dynamic typing accepted the writes; EF's typed materializer then blew
+    /// up with <c>FormatException("'UserDeclaredAt' was not recognized as a valid DateTime")</c>
+    /// on every read, and CoreSync's Postgres upload pipeline forwarded the strings
+    /// to the server which rejected them with <c>42804</c>.
+    ///
+    /// This method runs three idempotent UPDATEs against the open ADO.NET connection
+    /// (NOT EF — the bug is precisely that EF cannot read these rows). Safe defaults
+    /// match the model in <c>Models/VocabularyProgress.cs</c>:
+    ///   • <c>UserDeclaredAt</c>    → NULL (DateTime?, nullable in the migration)
+    ///   • <c>VerificationState</c> → 0    (VerificationStatus.None)
+    ///   • <c>IsUserDeclared</c>    → 0    (false, model default)
+    ///
+    /// Idempotent — second run finds nothing to repair, returns silently.
+    /// On a fresh DB where the table doesn't yet exist (pre-MigrateAsync first run),
+    /// silently returns — does NOT throw.
+    ///
+    /// Defined outside the IOS/ANDROID/MACCATALYST conditional so it's reachable
+    /// from the unit-test project (which builds against the Shared project's
+    /// <c>net10.0</c> target). It's still only invoked from <c>PatchMissingColumnsAsync</c>
+    /// on mobile platforms.
+    ///
+    /// References:
+    ///  • <c>.squad/decisions/inbox/troubleshooter-coresync-vocabprogress-userdeclaredat.md</c>
+    ///  • <c>docs/captain-runbook-vocabprogress-repair.md</c> (manual unblock)
+    ///  • GitHub issue: TBD (filed alongside the PR that introduces this method)
+    /// </summary>
+    internal async Task RepairTaintedVocabularyProgressAsync(System.Data.Common.DbConnection conn)
+    {
+        try
+        {
+            // First-run / pre-migration safety: if the table doesn't exist yet,
+            // there's nothing to repair. Don't throw — let MigrateAsync create it.
+            using (var tableCmd = conn.CreateCommand())
+            {
+                tableCmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='VocabularyProgress'";
+                if (Convert.ToInt64(await tableCmd.ExecuteScalarAsync()) == 0)
+                {
+                    _logger.LogDebug("RepairTaintedVocabularyProgressAsync: VocabularyProgress table does not yet exist — skipping (fresh DB).");
+                    return;
+                }
+            }
 
+            // Three idempotent UPDATEs. Each is independent so a partial taint
+            // (one column tainted, others clean) is repaired correctly.
+            int totalRepaired = 0;
+
+            using (var fixUserDeclaredAt = conn.CreateCommand())
+            {
+                fixUserDeclaredAt.CommandText =
+                    "UPDATE \"VocabularyProgress\" SET \"UserDeclaredAt\" = NULL " +
+                    "WHERE \"UserDeclaredAt\" = 'UserDeclaredAt'";
+                var rows = await fixUserDeclaredAt.ExecuteNonQueryAsync();
+                if (rows > 0)
+                {
+                    _logger.LogWarning(
+                        "Repaired {Rows} tainted VocabularyProgress rows (UserDeclaredAt='UserDeclaredAt' → NULL) — see docs/captain-runbook-vocabprogress-repair.md for context",
+                        rows);
+                    totalRepaired += rows;
+                }
+            }
+
+            using (var fixVerificationState = conn.CreateCommand())
+            {
+                fixVerificationState.CommandText =
+                    "UPDATE \"VocabularyProgress\" SET \"VerificationState\" = 0 " +
+                    "WHERE \"VerificationState\" = 'VerificationState'";
+                var rows = await fixVerificationState.ExecuteNonQueryAsync();
+                if (rows > 0)
+                {
+                    _logger.LogWarning(
+                        "Repaired {Rows} tainted VocabularyProgress rows (VerificationState='VerificationState' → 0) — see docs/captain-runbook-vocabprogress-repair.md for context",
+                        rows);
+                    totalRepaired += rows;
+                }
+            }
+
+            using (var fixIsUserDeclared = conn.CreateCommand())
+            {
+                fixIsUserDeclared.CommandText =
+                    "UPDATE \"VocabularyProgress\" SET \"IsUserDeclared\" = 0 " +
+                    "WHERE \"IsUserDeclared\" = 'IsUserDeclared'";
+                var rows = await fixIsUserDeclared.ExecuteNonQueryAsync();
+                if (rows > 0)
+                {
+                    _logger.LogWarning(
+                        "Repaired {Rows} tainted VocabularyProgress rows (IsUserDeclared='IsUserDeclared' → 0) — see docs/captain-runbook-vocabprogress-repair.md for context",
+                        rows);
+                    totalRepaired += rows;
+                }
+            }
+
+            if (totalRepaired == 0)
+            {
+                _logger.LogDebug("RepairTaintedVocabularyProgressAsync: no tainted VocabularyProgress rows found.");
+            }
+        }
+        catch (Exception ex)
+        {
+            // Defensive guard — never let this fail the startup path. The repair is
+            // best-effort; if it can't run, the existing FormatException toast will
+            // still surface and Captain's runbook (docs/captain-runbook-vocabprogress-repair.md)
+            // remains the manual fallback.
+            _logger.LogError(ex,
+                "RepairTaintedVocabularyProgressAsync failed (non-fatal); see docs/captain-runbook-vocabprogress-repair.md for manual repair steps");
+        }
+    }
 }

--- a/tests/SentenceStudio.UnitTests/Services/RepairTaintedVocabularyProgressTests.cs
+++ b/tests/SentenceStudio.UnitTests/Services/RepairTaintedVocabularyProgressTests.cs
@@ -1,0 +1,362 @@
+// Regression tests for RepairTaintedVocabularyProgressAsync — defensive self-repair
+// against the one-time CoreSync corruption event documented in
+// .squad/decisions/inbox/troubleshooter-coresync-vocabprogress-userdeclaredat.md
+//
+// The bug: every row in VocabularyProgress on at least one Mac Catalyst client
+// had literal column NAMES stored as values:
+//   UserDeclaredAt    = 'UserDeclaredAt'
+//   VerificationState = 'VerificationState'
+//   IsUserDeclared    = 'IsUserDeclared'
+// EF then threw FormatException on every read; CoreSync forwarded the strings
+// to Postgres which rejected them with 42804.
+//
+// "If a bug came back, it needs a test." (AGENTS.md)
+
+using CoreSync;
+using CoreSync.Http.Client;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SentenceStudio.Data;
+using SentenceStudio.Services;
+using SentenceStudio.Shared.Models;
+
+namespace SentenceStudio.UnitTests.Services;
+
+public class RepairTaintedVocabularyProgressTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly SyncService _sut;
+
+    public RepairTaintedVocabularyProgressTests()
+    {
+        // Single shared in-memory connection so the table survives across calls.
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        // Build SyncService with mocks. The repair method only touches _logger and
+        // the DbConnection passed in — the sync providers are never invoked.
+        var localSync = new Mock<ISyncProvider>().Object;
+        var remoteSync = new Mock<ISyncProviderHttpClient>().Object;
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        _sut = new SyncService(localSync, remoteSync, NullLogger<SyncService>.Instance, serviceProvider);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+    }
+
+    /// <summary>
+    /// Creates a minimal VocabularyProgress table mirroring the columns the repair
+    /// method writes to. We don't need the full schema — just the three repaired
+    /// columns plus an Id PK so we can address rows individually.
+    /// </summary>
+    private void CreateMinimalSchema()
+    {
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = @"
+            CREATE TABLE ""VocabularyProgress"" (
+                ""Id"" TEXT NOT NULL PRIMARY KEY,
+                ""UserDeclaredAt"" TEXT NULL,
+                ""VerificationState"" INTEGER NOT NULL,
+                ""IsUserDeclared"" INTEGER NOT NULL
+            );";
+        cmd.ExecuteNonQuery();
+    }
+
+    private void InsertRow(string id, object userDeclaredAt, object verificationState, object isUserDeclared)
+    {
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = @"
+            INSERT INTO ""VocabularyProgress"" (""Id"", ""UserDeclaredAt"", ""VerificationState"", ""IsUserDeclared"")
+            VALUES ($id, $uda, $vs, $iud)";
+        cmd.Parameters.AddWithValue("$id", id);
+        cmd.Parameters.AddWithValue("$uda", userDeclaredAt);
+        cmd.Parameters.AddWithValue("$vs", verificationState);
+        cmd.Parameters.AddWithValue("$iud", isUserDeclared);
+        cmd.ExecuteNonQuery();
+    }
+
+    private (string? userDeclaredAt, string verificationState, string isUserDeclared) ReadRow(string id)
+    {
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = @"
+            SELECT ""UserDeclaredAt"", ""VerificationState"", ""IsUserDeclared""
+            FROM ""VocabularyProgress"" WHERE ""Id"" = $id";
+        cmd.Parameters.AddWithValue("$id", id);
+        using var reader = cmd.ExecuteReader();
+        reader.Read();
+        return (
+            reader.IsDBNull(0) ? null : reader.GetValue(0)?.ToString(),
+            reader.GetValue(1)?.ToString() ?? string.Empty,
+            reader.GetValue(2)?.ToString() ?? string.Empty);
+    }
+
+    private long CountRowsMatching(string sqlPredicate)
+    {
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = $"SELECT COUNT(*) FROM \"VocabularyProgress\" WHERE {sqlPredicate}";
+        return Convert.ToInt64(cmd.ExecuteScalar());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: Missing table (fresh DB, pre-MigrateAsync) — must NOT throw.
+    // ─────────────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task Repair_WhenTableDoesNotExist_DoesNotThrow()
+    {
+        // No CreateMinimalSchema() — fresh DB.
+        var act = async () => await _sut.RepairTaintedVocabularyProgressAsync(_connection);
+        await act.Should().NotThrowAsync();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: Clean DB — no UPDATEs fire, no rows changed.
+    // ─────────────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task Repair_WithCleanData_LeavesRowsUntouched()
+    {
+        CreateMinimalSchema();
+        // Three clean rows: NULL UserDeclaredAt, VerificationState=0, IsUserDeclared=0.
+        InsertRow("clean-1", DBNull.Value, 0, 0);
+        InsertRow("clean-2", "2026-04-01 12:00:00", 1, 1);
+        InsertRow("clean-3", DBNull.Value, 2, 0);
+
+        await _sut.RepairTaintedVocabularyProgressAsync(_connection);
+
+        // Verify nothing changed.
+        var (uda1, vs1, iud1) = ReadRow("clean-1");
+        uda1.Should().BeNull();
+        vs1.Should().Be("0");
+        iud1.Should().Be("0");
+
+        var (uda2, vs2, iud2) = ReadRow("clean-2");
+        uda2.Should().Be("2026-04-01 12:00:00");
+        vs2.Should().Be("1");
+        iud2.Should().Be("1");
+
+        var (uda3, vs3, iud3) = ReadRow("clean-3");
+        uda3.Should().BeNull();
+        vs3.Should().Be("2");
+        iud3.Should().Be("0");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 3: Fully tainted DB (Captain's exact scenario, 1745-row analogue) —
+    //         all three columns repaired, all rows clean afterward.
+    // ─────────────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task Repair_WithFullyTaintedData_ResetsAllThreeColumnsToSafeDefaults()
+    {
+        CreateMinimalSchema();
+        // Insert 1745 rows, all tainted, mirroring Captain's machine.
+        for (int i = 0; i < 1745; i++)
+        {
+            InsertRow($"tainted-{i}", "UserDeclaredAt", "VerificationState", "IsUserDeclared");
+        }
+
+        await _sut.RepairTaintedVocabularyProgressAsync(_connection);
+
+        // Every row should now match the safe defaults.
+        CountRowsMatching("\"UserDeclaredAt\" IS NULL").Should().Be(1745);
+        CountRowsMatching("\"VerificationState\" = 0").Should().Be(1745);
+        CountRowsMatching("\"IsUserDeclared\" = 0").Should().Be(1745);
+
+        // And no row still carries the tainted literal values.
+        CountRowsMatching("\"UserDeclaredAt\" = 'UserDeclaredAt'").Should().Be(0);
+        CountRowsMatching("\"VerificationState\" = 'VerificationState'").Should().Be(0);
+        CountRowsMatching("\"IsUserDeclared\" = 'IsUserDeclared'").Should().Be(0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 4: Partial taint — only the affected columns are touched, clean
+    //         columns on the same row are left alone.
+    // ─────────────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task Repair_WithPartialTaint_OnlyAffectedColumnsAreReset()
+    {
+        CreateMinimalSchema();
+        // Row tainted only on UserDeclaredAt; other cols clean and meaningful.
+        InsertRow("partial-uda", "UserDeclaredAt", 2, 1);
+        // Row tainted only on VerificationState.
+        InsertRow("partial-vs", "2026-03-15 10:00:00", "VerificationState", 1);
+        // Row tainted only on IsUserDeclared.
+        InsertRow("partial-iud", "2026-03-15 10:00:00", 2, "IsUserDeclared");
+
+        await _sut.RepairTaintedVocabularyProgressAsync(_connection);
+
+        // partial-uda: UDA repaired to NULL, VerificationState=2 and IsUserDeclared=1 preserved.
+        var (uda, vs, iud) = ReadRow("partial-uda");
+        uda.Should().BeNull();
+        vs.Should().Be("2");
+        iud.Should().Be("1");
+
+        // partial-vs: VerificationState repaired to 0, others preserved.
+        var (uda2, vs2, iud2) = ReadRow("partial-vs");
+        uda2.Should().Be("2026-03-15 10:00:00");
+        vs2.Should().Be("0");
+        iud2.Should().Be("1");
+
+        // partial-iud: IsUserDeclared repaired to 0, others preserved.
+        var (uda3, vs3, iud3) = ReadRow("partial-iud");
+        uda3.Should().Be("2026-03-15 10:00:00");
+        vs3.Should().Be("2");
+        iud3.Should().Be("0");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 5: Idempotency — second run finds nothing to repair, no rows changed.
+    // ─────────────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task Repair_RunTwice_SecondRunIsNoOp()
+    {
+        CreateMinimalSchema();
+        for (int i = 0; i < 50; i++)
+        {
+            InsertRow($"tainted-{i}", "UserDeclaredAt", "VerificationState", "IsUserDeclared");
+        }
+
+        // First run: repairs all 50.
+        await _sut.RepairTaintedVocabularyProgressAsync(_connection);
+        CountRowsMatching("\"UserDeclaredAt\" = 'UserDeclaredAt'").Should().Be(0);
+
+        // Capture state after first run for diff.
+        var snapshotBefore = ReadRow("tainted-0");
+
+        // Second run: no-op.
+        await _sut.RepairTaintedVocabularyProgressAsync(_connection);
+
+        var snapshotAfter = ReadRow("tainted-0");
+        snapshotAfter.Should().BeEquivalentTo(snapshotBefore);
+
+        // Still clean.
+        CountRowsMatching("\"UserDeclaredAt\" IS NULL").Should().Be(50);
+        CountRowsMatching("\"VerificationState\" = 0").Should().Be(50);
+        CountRowsMatching("\"IsUserDeclared\" = 0").Should().Be(50);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 6: EF round-trip — after repair, EF can materialize VocabularyProgress
+    //         rows without throwing FormatException, and the cleaned values
+    //         round-trip through SaveChanges/Reload with correct CLR types.
+    // ─────────────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task Repair_AfterRepair_EFCanMaterializeAndRoundTripVocabularyProgress()
+    {
+        // Use the real ApplicationDbContext to validate end-to-end EF behavior.
+        var efConnection = new SqliteConnection("DataSource=:memory:");
+        efConnection.Open();
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddDbContext<ApplicationDbContext>(opts => opts.UseSqlite(efConnection));
+            using var serviceProvider = services.BuildServiceProvider();
+
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                await db.Database.EnsureCreatedAsync();
+            }
+
+            // Disable FK enforcement for this raw INSERT — we don't care about the
+            // VocabularyWord/User parents for the materialization smoke test, and
+            // EnsureCreated turns FK enforcement on. The repair method itself doesn't
+            // touch FKs, so this only relaxes the test fixture.
+            using (var fkCmd = efConnection.CreateCommand())
+            {
+                fkCmd.CommandText = "PRAGMA foreign_keys = OFF;";
+                await fkCmd.ExecuteNonQueryAsync();
+            }
+
+            // Inject a tainted row directly via raw SQL (mirrors the corruption event).
+            var taintedId = Guid.NewGuid().ToString();
+            using (var insertCmd = efConnection.CreateCommand())
+            {
+                insertCmd.CommandText = @"
+                    INSERT INTO ""VocabularyProgress""
+                        (""Id"", ""VocabularyWordId"", ""UserId"",
+                         ""MasteryScore"", ""TotalAttempts"", ""CorrectAttempts"",
+                         ""CurrentStreak"", ""ProductionInStreak"",
+                         ""RecognitionAttempts"", ""RecognitionCorrect"",
+                         ""ProductionAttempts"", ""ProductionCorrect"",
+                         ""ApplicationAttempts"", ""ApplicationCorrect"",
+                         ""CurrentPhase"", ""ReviewInterval"", ""EaseFactor"",
+                         ""MultipleChoiceCorrect"", ""TextEntryCorrect"",
+                         ""IsPromoted"", ""IsCompleted"",
+                         ""IsUserDeclared"", ""UserDeclaredAt"", ""VerificationState"",
+                         ""FirstSeenAt"", ""LastPracticedAt"",
+                         ""ExposureCount"",
+                         ""CreatedAt"", ""UpdatedAt"")
+                    VALUES
+                        ($id, 'word-1', 'user-1',
+                         0.0, 0, 0,
+                         0.0, 0,
+                         0, 0,
+                         0, 0,
+                         0, 0,
+                         0, 1, 2.5,
+                         0, 0,
+                         0, 0,
+                         'IsUserDeclared', 'UserDeclaredAt', 'VerificationState',
+                         '2026-03-15 10:00:00', '2026-03-15 10:00:00',
+                         0,
+                         '2026-03-15 10:00:00', '2026-03-15 10:00:00');";
+                insertCmd.Parameters.AddWithValue("$id", taintedId);
+                await insertCmd.ExecuteNonQueryAsync();
+            }
+
+            // Sanity check: BEFORE repair, EF would throw FormatException trying to
+            // materialize this row (the bug we are defending against).
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                var act = async () => await db.VocabularyProgresses.AsNoTracking().ToListAsync();
+                await act.Should().ThrowAsync<FormatException>(
+                    "EF can't parse the literal string 'UserDeclaredAt' as a DateTime — this is the user-facing bug");
+            }
+
+            // Run repair.
+            await _sut.RepairTaintedVocabularyProgressAsync(efConnection);
+
+            // AFTER repair: EF materializes cleanly with safe defaults.
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                var rows = await db.VocabularyProgresses.AsNoTracking().ToListAsync();
+                rows.Should().HaveCount(1);
+                var repaired = rows[0];
+                repaired.UserDeclaredAt.Should().BeNull();
+                repaired.VerificationState.Should().Be(VerificationStatus.None);
+                repaired.IsUserDeclared.Should().BeFalse();
+            }
+
+            // Round-trip: write meaningful values back through EF, reload, verify CLR types.
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                var entity = await db.VocabularyProgresses.SingleAsync(vp => vp.Id == taintedId);
+                entity.IsUserDeclared = true;
+                entity.UserDeclaredAt = new DateTime(2026, 5, 1, 12, 0, 0);
+                entity.VerificationState = VerificationStatus.Pending;
+                await db.SaveChangesAsync();
+            }
+
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                var entity = await db.VocabularyProgresses.AsNoTracking().SingleAsync(vp => vp.Id == taintedId);
+                entity.IsUserDeclared.Should().BeTrue();
+                entity.UserDeclaredAt.Should().Be(new DateTime(2026, 5, 1, 12, 0, 0));
+                entity.VerificationState.Should().Be(VerificationStatus.Pending);
+            }
+        }
+        finally
+        {
+            efConnection.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

On Captain's Mac Catalyst client, all 1745 rows of `VocabularyProgress` have the literal column NAMES stored as values: `UserDeclaredAt='UserDeclaredAt'`, `VerificationState='VerificationState'`, `IsUserDeclared='IsUserDeclared'`. Origin is a one-time CoreSync corruption event we cannot reproduce from any current code path. The schema itself is fine. EF chokes on the read with `DateTime.Parse('UserDeclaredAt')` → toast on every vocab page. Postgres rejects the upload with `42804`. Same root cause, two surfaces.

Full diagnosis (Round 1 + Round 2): `.squad/decisions/inbox/troubleshooter-coresync-vocabprogress-userdeclaredat.md` (gitignored — local working copy).

## What this PR does

**Defense in depth, not the immediate unblock.** Captain's running Mac Catalyst app is unblocked by hand using `docs/captain-runbook-vocabprogress-repair.md`. This PR adds the same repair into the startup path so any client that ever picks up tainted rows from sync self-heals before EF gets a chance to FormatException.

### `RepairTaintedVocabularyProgressAsync` in `SyncService.cs`

- New `internal` method on `SyncService`, defined outside the `IOS||ANDROID||MACCATALYST` `#if` so it's reachable from the test project; **invoked from `PatchMissingColumnsAsync`** on mobile only, **after column patching but before `MigrateAsync`** so EF never tries to materialize a tainted row.
- Three idempotent plain-ADO.NET UPDATEs (NOT EF — the bug is precisely that EF can't read these rows):
  ```sql
  UPDATE VocabularyProgress SET UserDeclaredAt    = NULL WHERE UserDeclaredAt    = 'UserDeclaredAt';
  UPDATE VocabularyProgress SET VerificationState = 0    WHERE VerificationState = 'VerificationState';
  UPDATE VocabularyProgress SET IsUserDeclared    = 0    WHERE IsUserDeclared    = 'IsUserDeclared';
  ```
- Defaults match `Models/VocabularyProgress.cs` (`UserDeclaredAt: DateTime?` → `NULL`; `VerificationState: VerificationStatus.None` → `0`; `IsUserDeclared: bool` default `false` → `0`).
- Pre-migration safety: if the table doesn't exist yet (fresh DB), logs debug and returns — no throw.
- Each successful UPDATE logs a Warning at `ILogger<SyncService>` with `{Rows}` repaired and a doc link.
- Outer `try/catch` keeps it non-fatal — startup is never blocked by the repair.

### Tests (`tests/SentenceStudio.UnitTests/Services/RepairTaintedVocabularyProgressTests.cs`)

xUnit + FluentAssertions + Moq + in-memory SQLite + real `ApplicationDbContext`. **6 tests, all green.**

| # | Scenario | Asserts |
|---|---|---|
| 1 | Fresh DB, table missing | No throw |
| 2 | Clean DB | Zero UPDATEs, all rows byte-identical |
| 3 | Fully tainted DB (1745 rows, mirroring Captain's machine) | All three columns reset to safe defaults |
| 4 | Partial taint (one column tainted per row) | Only the affected column updates; clean columns preserved |
| 5 | Idempotent | Second run no-op, row state unchanged |
| 6 | EF round-trip | Before repair: EF throws `FormatException` (proves the original bug). After repair: `ToListAsync()` materializes cleanly; round-trip via `SaveChanges` preserves `DateTime?`, enum, and `bool` CLR types |

`InternalsVisibleTo("SentenceStudio.UnitTests")` added to `SentenceStudio.Shared.csproj` so the test project can reach the `internal` repair method without widening the public API.

## CoreSync upstream defects observed (NOT filed per Captain's standing rule)

Per Round 2 diagnosis — three real defects in CoreSync `0.1.122/0.1.127/0.1.128` make this class of corruption easier to propagate. Captain has not yet decided whether to file an upstream issue, so they're listed here as evidence only:

1. `CoreSync.Sqlite.GetValueFromRecord` (~line 939) and `CoreSync.PostgreSQL.GetValueFromRecord` (~line 1064): no `Nullable<T>` / `enum` handling; falls through to `r.GetValue(ord)`, returning the raw text as `string` for SQLite TEXT-typed `DateTime?` columns.
2. `CoreSync.PostgreSQL.ConvertValueForColumn` (~line 1576): on `DateTime.TryParse` failure for a `timestamptz` column, **forwards the unparsed string to the database** instead of fail-fast. This produced the verbatim `42804` error in Round 1.
3. `SyncItemValue.DetectTypeOfObject` (~line 780): infers wire type purely from runtime CLR type, so a silently-demoted `string` round-trips as `SyncItemValueType.String` with no warning.

## Validation gates

### Build
```
dotnet build src/SentenceStudio.Shared/SentenceStudio.Shared.csproj
→ 0 Error(s), 656 Warning(s) (all pre-existing IL2026/EF1002 trimming/SQL-injection warnings on unrelated files)
```

### Tests
```
dotnet test --filter FullyQualifiedName~RepairTaintedVocabularyProgressTests
→ Passed!  - Failed: 0, Passed: 6, Skipped: 0, Total: 6, Duration: 640 ms
```

Full UnitTests suite: 505/506 passing. The one failure (`DeterministicPlanBuilderResourceSelectionTests.ResourceUsed15DaysAgo_ShouldNotBeTreatedAsNeverUsed`) is **pre-existing on `main`**, in plan-generation date-window logic — unrelated to sync/VocabularyProgress.

### `bash scripts/validate-mobile-migrations.sh`
```
📦 Building net10.0-maccatalyst...
✅ Build succeeded
🚀 Launching app in background...
⏳ Waiting for maui devflow agent to connect (timeout: 120s)...
✅ Agent connected
⏳ Giving app 15s to complete startup + migrations...
📋 Fetching native logs (last 500 lines)...
🔍 Scanning for migration/schema errors...
✅ Mobile migrations validated on net10.0-maccatalyst — no errors found
```

(Two informational warnings during the run: native log fetch fallback and the optional "sanity check passed" string match. The script's hard error-grep ran clean and the script exits with the success banner.)

## Deferred follow-ups

- **SQLite↔Postgres CoreSync round-trip test.** Troubleshooter's full plan included a pipeline test that provisions both providers, syncs a clean row through, and asserts no `42804` and no `SyncItemValueType.String` for the affected columns. The repo doesn't currently have a Postgres test container fixture wired into `SentenceStudio.UnitTests`, so this would require new infrastructure — separate PR.
- **Stale `0.1.128-local` CoreSync nupkgs in `lib/coresync/`.** Decompile shows zero behavioural change vs `0.1.127`. Safe to delete in a follow-up; not touched here to keep this PR minimal.
- **Upstream CoreSync issue.** Held per Captain's standing rule; defects are documented above for reference.
- **`__schema_repairs` telemetry table.** Open question from Round 2 — would let us track which DBs ever needed the repair. Not implemented; deferred to Captain's call.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
