### PR TITLE
fix(auth): enforce lockout and move email-confirm to post-auth in Login

### DIFF
--- a/src/SentenceStudio.Api/Auth/AuthEndpoints.cs
+++ b/src/SentenceStudio.Api/Auth/AuthEndpoints.cs
@@ -132,16 +132,25 @@ public static class AuthEndpoints
             return Results.Unauthorized();
         }
 
-        if (!await userManager.IsEmailConfirmedAsync(user))
+        // Enforce account lockout before checking the password
+        if (await userManager.IsLockedOutAsync(user))
         {
-            // Auto-confirm migrated accounts (they had no email confirmation requirement before)
-            // and dev-mode accounts
-            var confirmToken = await userManager.GenerateEmailConfirmationTokenAsync(user);
-            await userManager.ConfirmEmailAsync(user, confirmToken);
-            logger.LogInformation("Auto-confirmed email for {Email} (migrated or unconfirmed account)", request.Email);
+            logger.LogWarning("Login rejected for {Email}: account is locked out", request.Email);
+            return Results.Problem("Account is temporarily locked. Please try again later.", statusCode: 429);
         }
 
         if (!await userManager.CheckPasswordAsync(user, request.Password))
+        {
+            await userManager.AccessFailedAsync(user);
+            return Results.Unauthorized();
+        }
+
+        // Password is correct — reset the failure counter
+        await userManager.ResetAccessFailedCountAsync(user);
+
+        // Email confirmation check moved here (after password verification) so that a wrong-password
+        // request cannot auto-confirm an account as a side-effect
+        if (!await userManager.IsEmailConfirmedAsync(user))
         {
             return Results.Unauthorized();
         }

--- a/src/SentenceStudio.WebApp/Auth/ServerAuthService.cs
+++ b/src/SentenceStudio.WebApp/Auth/ServerAuthService.cs
@@ -101,11 +101,26 @@ public class ServerAuthService : IAuthService
         var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
 
         var user = await userManager.FindByEmailAsync(email);
-        if (user is null || !await userManager.CheckPasswordAsync(user, password))
+        if (user is null)
         {
-            _logger.LogWarning("Sign-in failed for {Email}", email);
+            _logger.LogWarning("Sign-in failed for {Email}: user not found", email);
             return null;
         }
+
+        if (await userManager.IsLockedOutAsync(user))
+        {
+            _logger.LogWarning("Sign-in rejected for {Email}: account is locked out", email);
+            return null;
+        }
+
+        if (!await userManager.CheckPasswordAsync(user, password))
+        {
+            await userManager.AccessFailedAsync(user);
+            _logger.LogWarning("Sign-in failed for {Email}: wrong password", email);
+            return null;
+        }
+
+        await userManager.ResetAccessFailedCountAsync(user);
 
         // Generate a one-time auto-sign-in token
         var token = await userManager.GenerateUserTokenAsync(

--- a/tests/SentenceStudio.Api.Tests/IdentityAuthTests.cs
+++ b/tests/SentenceStudio.Api.Tests/IdentityAuthTests.cs
@@ -153,6 +153,63 @@ public class IdentityAuthTests : IClassFixture<JwtBearerApiFactory>
             "refresh token should be rotated");
     }
 
+    [Fact]
+    public async Task Login_WrongPassword_DoesNotAutoConfirmEmail()
+    {
+        var email = $"no-autoconfirm-{Guid.NewGuid():N}@test.local";
+
+        // Create user directly with unconfirmed email
+        using var scope = _factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var user = new ApplicationUser { UserName = email, Email = email, DisplayName = "NoAutoConfirm" };
+        (await userManager.CreateAsync(user, "Test1234!")).Succeeded.Should().BeTrue();
+
+        // Attempt login with the WRONG password
+        var response = await _client.PostAsJsonAsync("/api/auth/login", new
+        {
+            Email = email,
+            Password = "WrongPassword99!"
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+        // Email must still be unconfirmed — the failed login must not have auto-confirmed it
+        var updated = await userManager.FindByEmailAsync(email);
+        updated!.EmailConfirmed.Should().BeFalse(
+            "a failed login attempt must not auto-confirm the account's email");
+    }
+
+    [Fact]
+    public async Task Login_ExcessiveFailures_TriggersLockout()
+    {
+        var email = $"lockout-{Guid.NewGuid():N}@test.local";
+        const string correctPassword = "Test1234!";
+
+        await RegisterAndConfirmAsync(email, correctPassword);
+
+        // Identity default: MaxFailedAccessAttempts = 5
+        for (var i = 0; i < 5; i++)
+        {
+            var r = await _client.PostAsJsonAsync("/api/auth/login", new
+            {
+                Email = email,
+                Password = "WrongPassword99!"
+            });
+            r.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+                $"attempt {i + 1} with wrong password should return 401");
+        }
+
+        // After 5 failures the account should be locked; even the correct password must be rejected
+        var lockedResponse = await _client.PostAsJsonAsync("/api/auth/login", new
+        {
+            Email = email,
+            Password = correctPassword
+        });
+
+        lockedResponse.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
+            "account should be locked after exceeding MaxFailedAccessAttempts");
+    }
+
     // -- helpers --
 
     private async Task RegisterAndConfirmAsync(string email, string password)


### PR DESCRIPTION
## What

Two intertwined security bugs in the login path:

### Bug 1 — Pre-authentication email auto-confirm

`AuthEndpoints.cs` (lines 135–142) was calling `ConfirmEmailAsync` **before** verifying the password. Any anonymous caller who knew a registered email address could POST `/api/auth/login` with any password and the targeted account's email would be silently auto-confirmed as a side-effect — leaking that the address is registered and bypassing the email-verification requirement without user consent.

**Fix:** The email-confirmation block is removed entirely. After a successful password check, we do a read-only `IsEmailConfirmedAsync` and return 401 if unconfirmed — no mutation, no information leak.

### Bug 2 — Identity lockout bypass

Both `AuthEndpoints.cs` and `ServerAuthService.cs` called `UserManager.CheckPasswordAsync` directly. That method verifies the password hash but **does not record failed attempts or enforce account lockout**, so an attacker could brute-force any account's password despite the lockout policy configured in `Program.cs`.

**Fix:** Replaced with a manual lockout guard around the existing `CheckPasswordAsync` call (avoids introducing a `SignInManager` dependency into the minimal-API endpoint):

1. `IsLockedOutAsync` — return HTTP 429 immediately if locked out
2. `AccessFailedAsync` — increment the failure counter on a wrong password
3. `ResetAccessFailedCountAsync` — reset on success

Same pattern applied to `ServerAuthService.cs`.

## Files changed

| File | Change |
|---|---|
| `src/SentenceStudio.Api/Auth/AuthEndpoints.cs` | Lockout guard + email-confirm block moved/simplified |
| `src/SentenceStudio.WebApp/Auth/ServerAuthService.cs` | Lockout guard added |
| `tests/SentenceStudio.Api.Tests/IdentityAuthTests.cs` | 2 regression tests added |

## Regression tests added

- `Login_WrongPassword_DoesNotAutoConfirmEmail` — asserts `EmailConfirmed` stays `false` after a failed login
- `Login_ExcessiveFailures_TriggersLockout` — asserts the account is locked (HTTP 429) after 5 wrong-password attempts

## Verification

- `dotnet build src/SentenceStudio.Api/` — **0 errors**
- All `IdentityAuthTests` fail pre-existing (missing `IChatClient` DI in test host, 19 failures on `main` before this branch); the new test failures share the same root cause — the assertions themselves are not reached.