### PR TITLE
test: failing repro for vocab quiz scoring bugs (#189, #191)

### DIFF
--- a/.squad/agents/jayne/history.md
+++ b/.squad/agents/jayne/history.md
@@ -89,3 +89,45 @@ Zoe's M.E.AI 10.5 strategic recommendations executed via three-agent orchestrati
 
 **SHIP IT verdict**: All validation gates pass; zero regressions introduced. Production-ready.
 
+
+---
+
+## 2025-12-18 — Vocab Quiz Scoring Bug Cluster, Stream B Step 1 (failing repro tests for #189, #191)
+
+**Captain (David Ortinau)** approved the cluster plan; Zoe is Lead, I'm Tester (Stream B Step 1, repro-tests-only), Wash owns the fix (Step 2), Kaylee owns the UI sibling stream.
+
+**Shipped:**
+- Branch `test/vocab-quiz-scoring-repro-189-191` (off `main`, 2aab53d). Draft PR: https://github.com/davidortinau/SentenceStudio/pull/195
+- New file: `tests/SentenceStudio.UnitTests/Integration/VocabQuizScoringRepro189And191Tests.cs` (4 tests).
+- Pattern: `IClassFixture<PlanGenerationTestFixture>` — real EF Core + in-memory SQLite + DI, modeled on `MasteryAlgorithmIntegrationTests`. **Do not** use Moq on `VocabularyProgressService` / its repos — methods aren't virtual and the existing `Services/VocabularyProgressServiceTests.cs` is `<Compile Remove>`d in the csproj for that reason.
+
+**Captured failure signatures (against `main`):**
+
+`Repro191_NewWord_AllCorrect_DoesNotRotateOutBeforeFifthTurn` — FAIL
+```
+turn=1 mode=MC   streak=1.00 prodInStreak=0 mastery=0.143 sessMC=1 sessText=0 ReadyToRotateOut=False
+turn=2 mode=MC   streak=2.00 prodInStreak=0 mastery=0.286 sessMC=2 sessText=0 ReadyToRotateOut=False
+turn=3 mode=MC   streak=3.00 prodInStreak=0 mastery=0.429 sessMC=3 sessText=0 ReadyToRotateOut=False
+turn=4 mode=Text streak=4.50 prodInStreak=1 mastery=0.714 sessMC=3 sessText=1 ReadyToRotateOut=True   ← rotates here
+```
+
+`Repro189_*` (both PASS) — service math is correct for one MC attempt. `Accuracy=1.0`, `ProductionAttempts=0`. Captain's "2 production / 50% accuracy" panel readout therefore comes from the UI panel (or a duplicate-call path), not the service.
+
+**Hypothesis-disambiguation outcome:**
+- **#189 → Stream A (Kaylee).** Service is innocent; bug is in `VocabQuiz.razor` Learning Details panel (~395–460) reading legacy obsolete fields, OR in duplicate-fire of `RecordPendingAttemptAsync` (call sites at ~1245 / ~1394 / ~1490).
+- **#191 → Wash, Stream B Step 2.** Root cause is `VocabularyQuizItem.ReadyToRotateOut` Tier 2 (mastery>=0.50 OR streak>=3 + only SessionCorrectCount>=2 AND SessionTextCorrect>=1). Curve is too lenient; Wash should pause for Captain alignment via decisions.md before picking a corrected target curve.
+
+**Patterns / lessons learned for future test work in this repo:**
+
+1. **The unit-test project only references `SentenceStudio.Shared`.** The main `SentenceStudio` project doesn't build for `net10.0`, and several legacy test files are commented out as a result. Always confirm a service is in `.Shared` before writing tests against it. `VocabularyProgressService` is in `SentenceStudio.Shared/Services/VocabularyProgressService.cs`, namespace `SentenceStudio.Services`.
+2. **`VocabularyProgressRepository` and `VocabularyLearningContextRepository` take an `IServiceProvider`** — they cannot be cleanly mocked with Moq; use the real fixture.
+3. **`PlanGenerationTestFixture` is the canonical DI harness** for any service touching the DB. Static `TestUserId="test-user-1"`, `SeedResource(vocabWordCount:int)`, `GetResourceVocabularyWordIds`, `ClearAllData()`. Construct the service in the test ctor with `fixture.ServiceProvider.CreateScope()` and resolve the repos out of that scope.
+4. **`VocabularyAttempt.Phase` is a computed property derived from `(InputMode, ContextType)`.** Don't try to set Phase explicitly in tests — the service will auto-derive it. Use the literal strings the quiz uses: `"MultipleChoice"`, `"Text"`, `"Voice"`, `"TextEntry"`. ContextType `"Isolated"` is fine for unit tests.
+5. **`VocabularyQuizItem.Word` is required (constructor-init)** — I had to seed via `ApplicationDbContext.VocabularyWords.First(w=>w.Id==wordId)` from a fresh scope.
+6. **`DifficultyWeight` matters for streak math.** `1.0` for MC, `1.5` for Text — VocabQuiz.razor sets these explicitly; tests must mirror, or the streak math diverges from production.
+7. **Mode-selection rule from VocabQuiz.razor (~792–801):** `PendingRecognitionCheck` → MC; `CurrentStreak>=3 OR MasteryScore>=0.50` → Text; else MC. Mirrored as a private helper `ChooseQuizModeForTurn` in the test to keep simulations faithful.
+8. **Use FluentAssertions `AssertionScope`** to dump all expected/actual fields when one fails — critical for the PR description and for Wash's debugging.
+9. **CS0618 obsolete warnings on `RecognitionAttempts` / `ProductionAttempts`:** wrap assertions in `#pragma warning disable/restore CS0618` — these legacy fields are still updated by the service for back-compat and need to be asserted explicitly when proving recognition turns don't pollute production counters.
+10. **Don't disturb Kaylee's UI WIP.** Stashed `src/SentenceStudio.Shared/Resources/Strings/AppResources*.{cs,resx}` + `VocabQuiz.razor` + `docs/coresync-suspected-defects.md` under stash message `kaylee-stream-a-wip-vocab-quiz` before branching off `main`. Restore via `git checkout fix/vocab-quiz-ui-cluster-189-194 && git stash pop` when leaving Stream B.
+
+**Decision dropped:** `.squad/decisions/inbox/jayne-vocab-quiz-scoring-repro-189-191.md`.

--- a/tests/SentenceStudio.UnitTests/Integration/VocabQuizScoringRepro189And191Tests.cs
+++ b/tests/SentenceStudio.UnitTests/Integration/VocabQuizScoringRepro189And191Tests.cs
@@ -1,0 +1,352 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SentenceStudio.Data;
+using SentenceStudio.Services;
+using SentenceStudio.Shared.Models;
+using SentenceStudio.UnitTests.PlanGeneration;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SentenceStudio.UnitTests.Integration;
+
+/// <summary>
+/// Failing repro tests for the Vocabulary Quiz scoring bugs identified by Captain
+/// in issues #189 and #191. Author: Jayne (Tester) — Stream B Step 1.
+///
+/// These tests exist to:
+///   1. Pin down the EXPECTED post-state of VocabularyProgress after well-defined
+///      quiz interactions, so Wash has unambiguous targets to fix against.
+///   2. Disambiguate competing hypotheses for #189 (service double-increment vs
+///      UI panel reading legacy obsolete fields).
+///   3. Expose how aggressively new words rotate out today (#191), so the team
+///      can decide on a corrected curve.
+///
+/// Tests use the same in-memory SQLite + real EF Core fixture as
+/// <see cref="MasteryAlgorithmIntegrationTests"/>, so the failure signatures
+/// reflect production code paths, not mocks.
+/// </summary>
+public class VocabQuizScoringRepro189And191Tests
+    : IClassFixture<PlanGenerationTestFixture>, IDisposable
+{
+    private readonly PlanGenerationTestFixture _fixture;
+    private readonly VocabularyProgressService _progressService;
+    private readonly ITestOutputHelper _output;
+
+    public VocabQuizScoringRepro189And191Tests(
+        PlanGenerationTestFixture fixture,
+        ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+        _fixture.ClearAllData();
+        _fixture.SeedUserProfile();
+
+        var scope = fixture.ServiceProvider.CreateScope();
+        var progressRepo = scope.ServiceProvider.GetRequiredService<VocabularyProgressRepository>();
+        var contextRepo = new VocabularyLearningContextRepository(
+            fixture.ServiceProvider,
+            scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<VocabularyLearningContextRepository>());
+
+        _progressService = new VocabularyProgressService(
+            progressRepo,
+            contextRepo,
+            scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<VocabularyProgressService>(),
+            fixture.ServiceProvider);
+    }
+
+    public void Dispose() { }
+
+    // ---------------------------------------------------------------------
+    // #189 — Attempt counting / accuracy correctness
+    // ---------------------------------------------------------------------
+    //
+    // Captain's report: After ONE correct recognition turn on the word 털,
+    // the Learning Details panel shows "2 production attempts / 50% accuracy".
+    //
+    // Two competing hypotheses:
+    //   (a) ProgressService is double-incrementing on a single attempt.
+    //   (b) The Learning Details panel is reading legacy obsolete fields
+    //       that don't match the new streak-based truth.
+    //
+    // This test asserts the EXPECTED post-state per the bug report. If it
+    // FAILS, hypothesis (a) is correct — the service is buggy. If it PASSES,
+    // hypothesis (b) is correct — the bug is purely in the UI panel reading
+    // wrong fields, and the panel needs to be fixed (not the service).
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task Repro189_SingleCorrectRecognitionAttempt_ProducesExpectedPanelState()
+    {
+        // Arrange — a brand-new word with no prior progress, mimicking 털.
+        var resource = _fixture.SeedResource(vocabWordCount: 1);
+        var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
+
+        var attempt = MakeRecognitionAttempt(wordId, wasCorrect: true);
+
+        // Act — one correct multiple-choice (recognition) turn, exactly as the
+        // quiz issues via VocabQuiz.razor → ProgressService.RecordAttemptAsync.
+        var result = await _progressService.RecordAttemptAsync(attempt);
+
+        // Dump the row for the PR description so Wash sees the actual values.
+        _output.WriteLine(DumpProgress(result));
+
+        // Assert — every field the Learning Details panel reads must match the
+        // narrative of "ONE correct recognition turn".
+        using (new FluentAssertions.Execution.AssertionScope())
+        {
+            // Core counters (panel rows TotalAttempts / CorrectAttempts / Accuracy).
+            result.TotalAttempts.Should().Be(1,
+                "exactly one attempt was recorded");
+            result.CorrectAttempts.Should().Be(1,
+                "the single attempt was correct");
+            result.Accuracy.Should().Be(1.0f,
+                "1 correct ÷ 1 total = 100%, NOT the 50% Captain reported");
+
+            // Streak fields (panel rows CurrentStreak / ProductionInStreak).
+            result.CurrentStreak.Should().Be(1f,
+                "one correct MC at DifficultyWeight=1.0 yields streak 1");
+            result.ProductionInStreak.Should().Be(0,
+                "MultipleChoice is recognition, not production — must NOT be 2");
+
+            // Legacy obsolete fields — must not be incremented as production.
+#pragma warning disable CS0618
+            result.RecognitionAttempts.Should().Be(1,
+                "Phase=Recognition for InputMode=MultipleChoice");
+            result.RecognitionCorrect.Should().Be(1);
+            result.ProductionAttempts.Should().Be(0,
+                "no production attempts occurred");
+            result.ProductionCorrect.Should().Be(0);
+            result.ApplicationAttempts.Should().Be(0);
+            result.ApplicationCorrect.Should().Be(0);
+#pragma warning restore CS0618
+        }
+    }
+
+    /// <summary>
+    /// Companion test for #189: belt-and-suspenders assertion that a single
+    /// recognition (MultipleChoice) attempt does not touch any obsolete
+    /// production-side counter. If this test passes today (which the service
+    /// code suggests it will), the bug is in the panel layer — the panel must
+    /// stop displaying these legacy fields and read only the streak-based
+    /// truth.
+    /// </summary>
+    [Fact]
+    public async Task Repro189_SingleCorrectRecognition_LegacyProductionFieldsRemainZero()
+    {
+        var resource = _fixture.SeedResource(vocabWordCount: 1);
+        var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
+
+        var result = await _progressService.RecordAttemptAsync(
+            MakeRecognitionAttempt(wordId, wasCorrect: true));
+
+        _output.WriteLine(DumpProgress(result));
+
+#pragma warning disable CS0618
+        result.ProductionAttempts.Should().Be(0,
+            "Phase derived from MultipleChoice is Recognition; ProductionAttempts must NEVER be incremented for an MC turn (#189)");
+        result.ProductionCorrect.Should().Be(0,
+            "ProductionCorrect must stay zero on a recognition-only turn (#189)");
+        result.ProductionAccuracy.Should().Be(0,
+            "ProductionAccuracy = ProductionCorrect/ProductionAttempts must be 0 with no production turns (#189)");
+#pragma warning restore CS0618
+    }
+
+    // ---------------------------------------------------------------------
+    // #191 — Latter quiz rounds rapidly empty
+    // ---------------------------------------------------------------------
+    //
+    // Captain's report: User mastered 26 new words in 58 turns over 8 rounds.
+    // Round 8 showed only 2 words — new words rotate out far too quickly.
+    //
+    // Hypothesis: VocabularyQuizItem.ReadyToRotateOut Tier 2
+    // (mastery >= 0.50 OR streak >= 3) lets a brand-new word rotate after
+    // only 2-3 correct MC turns followed by a single Text turn — far less
+    // demonstration than 8 rounds × ~7 turns implies.
+    //
+    // The walk below mimics VocabQuiz.razor's ChooseInteractionMode logic:
+    //   • Default mode is MultipleChoice.
+    //   • Mode flips to Text once CurrentStreak >= 3 OR MasteryScore >= 0.50.
+    // We simulate ALL CORRECT answers and record the first turn at which
+    // VocabularyQuizItem.ReadyToRotateOut becomes true.
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task Repro191_NewWord_AllCorrect_DoesNotRotateOutBeforeFifthTurn()
+    {
+        // Arrange — one fresh word, no prior progress.
+        var resource = _fixture.SeedResource(vocabWordCount: 1);
+        var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
+        var word = SeedWordReference(wordId);
+
+        var quizItem = new VocabularyQuizItem
+        {
+            Word = word,
+            Progress = await _progressService.GetProgressAsync(wordId),
+            IsCurrent = true,
+        };
+
+        // Walk — at most 8 turns of all-correct answers, mirroring the quiz's
+        // mode-selection rule. Track ReadyToRotateOut at each turn boundary.
+        const int maxTurns = 8;
+        int? firstRotateTurn = null;
+        var trace = new List<string>();
+
+        for (int turn = 1; turn <= maxTurns; turn++)
+        {
+            // Replicate VocabQuiz.razor mode-selection from the current Progress.
+            string mode = ChooseQuizModeForTurn(quizItem);
+            float weight = mode == "Text" ? 1.5f : 1.0f;
+
+            var attempt = new VocabularyAttempt
+            {
+                VocabularyWordId = wordId,
+                UserId = PlanGenerationTestFixture.TestUserId,
+                Activity = "VocabularyQuiz",
+                InputMode = mode,
+                ContextType = "Isolated",
+                WasCorrect = true,
+                DifficultyWeight = weight,
+                ResponseTimeMs = 1500
+            };
+
+            quizItem.Progress = await _progressService.RecordAttemptAsync(attempt);
+
+            // Mirror the per-turn session counter bumps from VocabQuiz.razor.
+            quizItem.SessionCorrectCount++;
+            if (mode == "MultipleChoice") quizItem.SessionMCCorrect++;
+            else quizItem.SessionTextCorrect++;
+
+            trace.Add(
+                $"turn={turn} mode={mode} streak={quizItem.Progress.CurrentStreak:F2} "
+              + $"prodInStreak={quizItem.Progress.ProductionInStreak} "
+              + $"mastery={quizItem.Progress.MasteryScore:F3} "
+              + $"sessMC={quizItem.SessionMCCorrect} sessText={quizItem.SessionTextCorrect} "
+              + $"ReadyToRotateOut={quizItem.ReadyToRotateOut}");
+
+            if (quizItem.ReadyToRotateOut && firstRotateTurn is null)
+                firstRotateTurn = turn;
+        }
+
+        foreach (var line in trace) _output.WriteLine(line);
+        _output.WriteLine($"First ReadyToRotateOut turn: {firstRotateTurn?.ToString() ?? "never"}");
+
+        // Assertion — Captain reported that 26 fresh words mastered in just
+        // 58 turns over 8 rounds is too aggressive. A brand-new word receiving
+        // ALL CORRECT answers should NOT yet be eligible for rotation by turn 4.
+        // The expected curve is TBD (Wash + Captain to define), but turn-4
+        // rotation is well below any reasonable mastery bar — failing here
+        // exposes that #191 is real.
+        firstRotateTurn.Should().BeGreaterOrEqualTo(5,
+            "a brand-new word with 4 all-correct turns demonstrates too little mastery "
+          + "to rotate out — current Tier 2 logic flips this at turn 4 (3 MC + 1 Text), "
+          + "which is the rapid-empty behavior #191 describes");
+    }
+
+    /// <summary>
+    /// Documents (without prescribing) the current rotation behavior so that
+    /// when Wash lands the fix, the diff in this number tells everyone the
+    /// curve actually changed. Passing test — pure characterization.
+    /// </summary>
+    [Fact]
+    public async Task Repro191_CharacterizeCurrentBehavior_FreshWordRotatesAtTurnN()
+    {
+        var resource = _fixture.SeedResource(vocabWordCount: 1);
+        var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
+        var word = SeedWordReference(wordId);
+
+        var quizItem = new VocabularyQuizItem
+        {
+            Word = word,
+            Progress = await _progressService.GetProgressAsync(wordId),
+        };
+
+        int? firstRotateTurn = null;
+        for (int turn = 1; turn <= 12 && firstRotateTurn is null; turn++)
+        {
+            string mode = ChooseQuizModeForTurn(quizItem);
+            quizItem.Progress = await _progressService.RecordAttemptAsync(new VocabularyAttempt
+            {
+                VocabularyWordId = wordId,
+                UserId = PlanGenerationTestFixture.TestUserId,
+                Activity = "VocabularyQuiz",
+                InputMode = mode,
+                ContextType = "Isolated",
+                WasCorrect = true,
+                DifficultyWeight = mode == "Text" ? 1.5f : 1.0f,
+                ResponseTimeMs = 1500
+            });
+
+            quizItem.SessionCorrectCount++;
+            if (mode == "MultipleChoice") quizItem.SessionMCCorrect++;
+            else quizItem.SessionTextCorrect++;
+
+            if (quizItem.ReadyToRotateOut) firstRotateTurn = turn;
+        }
+
+        _output.WriteLine($"Characterization: fresh word with all-correct answers "
+            + $"first becomes ReadyToRotateOut at turn {firstRotateTurn?.ToString() ?? "never"}.");
+
+        firstRotateTurn.Should().NotBeNull(
+            "if rotation never happens, the test setup is wrong — a non-failing snapshot "
+          + "is fine here, but it must capture some turn number for the team to debate");
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static VocabularyAttempt MakeRecognitionAttempt(string wordId, bool wasCorrect) =>
+        new VocabularyAttempt
+        {
+            VocabularyWordId = wordId,
+            UserId = PlanGenerationTestFixture.TestUserId,
+            Activity = "VocabularyQuiz",
+            // VocabQuiz.razor sends the literal string "MultipleChoice"
+            // (not InputMode.MultipleChoice.ToString(), which happens to
+            // match) when userMode is the default for a fresh word.
+            InputMode = "MultipleChoice",
+            WasCorrect = wasCorrect,
+            DifficultyWeight = 1.0f,
+            ContextType = "Isolated",
+            ResponseTimeMs = 1500
+        };
+
+    /// <summary>
+    /// Mirror of VocabQuiz.razor's ChooseInteractionMode (lines 792-801):
+    ///   • PendingRecognitionCheck → MultipleChoice
+    ///   • CurrentStreak >= 3 OR MasteryScore >= 0.50 → Text
+    ///   • else → MultipleChoice
+    /// </summary>
+    private static string ChooseQuizModeForTurn(VocabularyQuizItem item)
+    {
+        if (item.PendingRecognitionCheck) return "MultipleChoice";
+        var streak = item.Progress?.CurrentStreak ?? 0f;
+        var mastery = item.Progress?.MasteryScore ?? 0f;
+        return (streak >= 3f || mastery >= 0.50f) ? "Text" : "MultipleChoice";
+    }
+
+    /// <summary>
+    /// Loads the seeded VocabularyWord row so VocabularyQuizItem has a
+    /// proper Word reference (required = constructor-init only).
+    /// </summary>
+    private VocabularyWord SeedWordReference(string wordId)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return db.VocabularyWords.AsQueryable().First(w => w.Id == wordId);
+    }
+
+    private static string DumpProgress(VocabularyProgress p)
+    {
+#pragma warning disable CS0618
+        return $"VocabularyProgress dump:\n"
+             + $"  TotalAttempts={p.TotalAttempts}, CorrectAttempts={p.CorrectAttempts}, Accuracy={p.Accuracy:F3}\n"
+             + $"  CurrentStreak={p.CurrentStreak:F2}, ProductionInStreak={p.ProductionInStreak}, MasteryScore={p.MasteryScore:F3}\n"
+             + $"  RecognitionAttempts={p.RecognitionAttempts}, RecognitionCorrect={p.RecognitionCorrect}\n"
+             + $"  ProductionAttempts={p.ProductionAttempts}, ProductionCorrect={p.ProductionCorrect}\n"
+             + $"  ApplicationAttempts={p.ApplicationAttempts}, ApplicationCorrect={p.ApplicationCorrect}\n"
+             + $"  IsKnown={p.IsKnown}, Status={p.Status}";
+#pragma warning restore CS0618
+    }
+}


### PR DESCRIPTION
**Stream B Step 1** of the Vocabulary Quiz bug cluster — failing-first regression tests for #189 and #191. **No production code changes.** Author: Jayne (Tester).

These are repro/regression tests that lock down the expected behavior so Wash (backend) and Kaylee (UI) have unambiguous targets. Wash's fix should turn the failing test green; Kaylee's UI fix is informed by the diagnostic that the service-side tests already pass.

## What was added

`tests/SentenceStudio.UnitTests/Integration/VocabQuizScoringRepro189And191Tests.cs` — 4 tests using the existing `PlanGenerationTestFixture` (real EF Core + in-memory SQLite + DI), modeled on `MasteryAlgorithmIntegrationTests`.

## Results on `main` (commit `2aab53d`)

```
Total tests: 4
     Passed: 3
     Failed: 1
```

| Test | #189/#191 | Result on main | Meaning |
|------|-----------|----------------|---------|
| `Repro189_SingleCorrectRecognitionAttempt_ProducesExpectedPanelState` | #189 | ✅ PASS | Service correctly records 1 attempt, 100% accuracy, no production-side bumps for a single correct MC turn |
| `Repro189_SingleCorrectRecognition_LegacyProductionFieldsRemainZero` | #189 | ✅ PASS | Obsolete `ProductionAttempts`/`ProductionCorrect` stay zero for a recognition turn |
| `Repro191_NewWord_AllCorrect_DoesNotRotateOutBeforeFifthTurn` | #191 | ❌ **FAIL** | Fresh word with 4 all-correct turns trips `ReadyToRotateOut=True` at turn 4 |
| `Repro191_CharacterizeCurrentBehavior_FreshWordRotatesAtTurnN` | #191 | ✅ PASS (snapshot) | Documents that the first rotation turn today is **4** |

## #189 — disambiguated

Two competing hypotheses going in:

- **(a)** `VocabularyProgressService` double-increments on a single attempt.
- **(b)** The Learning Details panel reads legacy/obsolete fields that don't match the new streak-based truth, or there's a duplicate UI call path.

**Both #189 service-side tests PASS on `main`.** Service math is correct:

```
VocabularyProgress dump (after one correct MultipleChoice attempt):
  TotalAttempts=1, CorrectAttempts=1, Accuracy=1.000
  CurrentStreak=1.00, ProductionInStreak=0, MasteryScore=0.143
  RecognitionAttempts=1, RecognitionCorrect=1
  ProductionAttempts=0, ProductionCorrect=0
```

→ Hypothesis **(b)** stands. The "2 production attempts / 50% accuracy" panel readout has to come from the UI layer, not the service. The most likely culprits are:

1. The Learning Details panel in `VocabQuiz.razor` reading obsolete legacy fields (e.g., `ProductionAttempts` directly) instead of the new streak-based fields, **or**
2. A double-call path through `RecordPendingAttemptAsync` (called from `NextItem`, `OverrideAsCorrect`, and one other site — possible duplicate-fire vector).

Both are UI/quiz-page concerns belonging to Kaylee's Stream A. The two passing service tests stay as regression guards so the service contract can't silently regress while the UI fix is in flight.

## #191 — confirmed

Captured trace from the failing test (one fresh word, all answers correct, mode chosen the same way `VocabQuiz.razor` chooses it — MC until `CurrentStreak>=3 OR MasteryScore>=0.5`, then Text):

```
turn=1 mode=MultipleChoice streak=1.00 prodInStreak=0 mastery=0.143 sessMC=1 sessText=0 ReadyToRotateOut=False
turn=2 mode=MultipleChoice streak=2.00 prodInStreak=0 mastery=0.286 sessMC=2 sessText=0 ReadyToRotateOut=False
turn=3 mode=MultipleChoice streak=3.00 prodInStreak=0 mastery=0.429 sessMC=3 sessText=0 ReadyToRotateOut=False
turn=4 mode=Text          streak=4.50 prodInStreak=1 mastery=0.714 sessMC=3 sessText=1 ReadyToRotateOut=True   ← rotation flips here
turn=5 mode=Text          streak=6.00 prodInStreak=2 mastery=1.000 sessMC=3 sessText=2 ReadyToRotateOut=True
turn=6 mode=Text          streak=7.50 prodInStreak=3 mastery=1.000 sessMC=3 sessText=3 ReadyToRotateOut=True
```

Failure message:

> Expected `firstRotateTurn` to be greater than or equal to 5 because a brand-new word with 4 all-correct turns demonstrates too little mastery to rotate out — current Tier 2 logic flips this at turn 4 (3 MC + 1 Text), which is the rapid-empty behavior #191 describes, but found 4.

Root cause is in `VocabularyQuizItem.ReadyToRotateOut` Tier 2 (lines 33–55 of `VocabularyQuizItem.cs`): once `MasteryScore >= 0.50` OR `CurrentStreak >= 3`, the only additional gates are `SessionCorrectCount>=2` AND `SessionTextCorrect>=1`. With the quiz's mode auto-flip kicking Text in at turn 4, those gates are met immediately. That matches Captain's report of 26 fresh words mastered in 58 turns over 8 rounds (~2.2 turns/word).

## How Wash should use this

1. Read the failing trace above.
2. Tighten Tier 2 in `VocabularyQuizItem.ReadyToRotateOut` (and/or the mode-flip threshold). Suggested rough targets: more required Text-correct turns, higher mastery floor, or per-word session minimums independent of the global session counters. **Don't pick the curve unilaterally** — discuss with Captain via `decisions.md` first.
3. Run `dotnet test --filter VocabQuizScoringRepro189And191Tests`. Both `Repro191_*` tests will need updating after the fix:
   - `Repro191_NewWord_AllCorrect_DoesNotRotateOutBeforeFifthTurn` should pass.
   - `Repro191_CharacterizeCurrentBehavior_*` should be updated to reflect the new first-rotation turn (or removed once the curve is canonical).

## How Kaylee should use this

1. The two `Repro189_*` tests **prove the service is fine**. Don't touch `VocabularyProgressService.RecordAttemptAsync` for #189.
2. Audit the Learning Details panel in `VocabQuiz.razor` (lines ~395–460) for any reads of legacy obsolete fields — replace with streak-based equivalents.
3. Audit the call sites of `RecordPendingAttemptAsync` for duplicate-fire (`NextItem` ~1245, `OverrideAsCorrect` ~1394, plus the third site near 1490).

## Out of scope for this PR

- Production code (no edits to `VocabularyProgressService`, `VocabularyQuizItem`, `VocabQuiz.razor`, etc.).
- The actual fix — that's Wash's Stream B Step 2 + Kaylee's Stream A.
- Mode-selection changes — the test's `ChooseQuizModeForTurn` mirrors the current `VocabQuiz.razor` rule verbatim; if the rule moves, the helper moves with it.

## Verification

```
$ dotnet build tests/SentenceStudio.UnitTests/SentenceStudio.UnitTests.csproj
Build succeeded. 0 Error(s)

$ dotnet test ... --filter "FullyQualifiedName~VocabQuizScoringRepro189And191Tests"
Total tests: 4 | Passed: 3 | Failed: 1
```

Branch: `test/vocab-quiz-scoring-repro-189-191`, off `main` (`2aab53d`). No conflicts with Kaylee's `fix/vocab-quiz-ui-cluster-189-194`.
