### PR TITLE
fix(vocab-quiz): tighten rotation curve for fresh words (#191)

### DIFF
--- a/.squad/agents/jayne/history.md
+++ b/.squad/agents/jayne/history.md
@@ -89,3 +89,45 @@ Zoe's M.E.AI 10.5 strategic recommendations executed via three-agent orchestrati
 
 **SHIP IT verdict**: All validation gates pass; zero regressions introduced. Production-ready.
 
+
+---
+
+## 2025-12-18 — Vocab Quiz Scoring Bug Cluster, Stream B Step 1 (failing repro tests for #189, #191)
+
+**Captain (David Ortinau)** approved the cluster plan; Zoe is Lead, I'm Tester (Stream B Step 1, repro-tests-only), Wash owns the fix (Step 2), Kaylee owns the UI sibling stream.
+
+**Shipped:**
+- Branch `test/vocab-quiz-scoring-repro-189-191` (off `main`, 2aab53d). Draft PR: https://github.com/davidortinau/SentenceStudio/pull/195
+- New file: `tests/SentenceStudio.UnitTests/Integration/VocabQuizScoringRepro189And191Tests.cs` (4 tests).
+- Pattern: `IClassFixture<PlanGenerationTestFixture>` — real EF Core + in-memory SQLite + DI, modeled on `MasteryAlgorithmIntegrationTests`. **Do not** use Moq on `VocabularyProgressService` / its repos — methods aren't virtual and the existing `Services/VocabularyProgressServiceTests.cs` is `<Compile Remove>`d in the csproj for that reason.
+
+**Captured failure signatures (against `main`):**
+
+`Repro191_NewWord_AllCorrect_DoesNotRotateOutBeforeFifthTurn` — FAIL
+```
+turn=1 mode=MC   streak=1.00 prodInStreak=0 mastery=0.143 sessMC=1 sessText=0 ReadyToRotateOut=False
+turn=2 mode=MC   streak=2.00 prodInStreak=0 mastery=0.286 sessMC=2 sessText=0 ReadyToRotateOut=False
+turn=3 mode=MC   streak=3.00 prodInStreak=0 mastery=0.429 sessMC=3 sessText=0 ReadyToRotateOut=False
+turn=4 mode=Text streak=4.50 prodInStreak=1 mastery=0.714 sessMC=3 sessText=1 ReadyToRotateOut=True   ← rotates here
+```
+
+`Repro189_*` (both PASS) — service math is correct for one MC attempt. `Accuracy=1.0`, `ProductionAttempts=0`. Captain's "2 production / 50% accuracy" panel readout therefore comes from the UI panel (or a duplicate-call path), not the service.
+
+**Hypothesis-disambiguation outcome:**
+- **#189 → Stream A (Kaylee).** Service is innocent; bug is in `VocabQuiz.razor` Learning Details panel (~395–460) reading legacy obsolete fields, OR in duplicate-fire of `RecordPendingAttemptAsync` (call sites at ~1245 / ~1394 / ~1490).
+- **#191 → Wash, Stream B Step 2.** Root cause is `VocabularyQuizItem.ReadyToRotateOut` Tier 2 (mastery>=0.50 OR streak>=3 + only SessionCorrectCount>=2 AND SessionTextCorrect>=1). Curve is too lenient; Wash should pause for Captain alignment via decisions.md before picking a corrected target curve.
+
+**Patterns / lessons learned for future test work in this repo:**
+
+1. **The unit-test project only references `SentenceStudio.Shared`.** The main `SentenceStudio` project doesn't build for `net10.0`, and several legacy test files are commented out as a result. Always confirm a service is in `.Shared` before writing tests against it. `VocabularyProgressService` is in `SentenceStudio.Shared/Services/VocabularyProgressService.cs`, namespace `SentenceStudio.Services`.
+2. **`VocabularyProgressRepository` and `VocabularyLearningContextRepository` take an `IServiceProvider`** — they cannot be cleanly mocked with Moq; use the real fixture.
+3. **`PlanGenerationTestFixture` is the canonical DI harness** for any service touching the DB. Static `TestUserId="test-user-1"`, `SeedResource(vocabWordCount:int)`, `GetResourceVocabularyWordIds`, `ClearAllData()`. Construct the service in the test ctor with `fixture.ServiceProvider.CreateScope()` and resolve the repos out of that scope.
+4. **`VocabularyAttempt.Phase` is a computed property derived from `(InputMode, ContextType)`.** Don't try to set Phase explicitly in tests — the service will auto-derive it. Use the literal strings the quiz uses: `"MultipleChoice"`, `"Text"`, `"Voice"`, `"TextEntry"`. ContextType `"Isolated"` is fine for unit tests.
+5. **`VocabularyQuizItem.Word` is required (constructor-init)** — I had to seed via `ApplicationDbContext.VocabularyWords.First(w=>w.Id==wordId)` from a fresh scope.
+6. **`DifficultyWeight` matters for streak math.** `1.0` for MC, `1.5` for Text — VocabQuiz.razor sets these explicitly; tests must mirror, or the streak math diverges from production.
+7. **Mode-selection rule from VocabQuiz.razor (~792–801):** `PendingRecognitionCheck` → MC; `CurrentStreak>=3 OR MasteryScore>=0.50` → Text; else MC. Mirrored as a private helper `ChooseQuizModeForTurn` in the test to keep simulations faithful.
+8. **Use FluentAssertions `AssertionScope`** to dump all expected/actual fields when one fails — critical for the PR description and for Wash's debugging.
+9. **CS0618 obsolete warnings on `RecognitionAttempts` / `ProductionAttempts`:** wrap assertions in `#pragma warning disable/restore CS0618` — these legacy fields are still updated by the service for back-compat and need to be asserted explicitly when proving recognition turns don't pollute production counters.
+10. **Don't disturb Kaylee's UI WIP.** Stashed `src/SentenceStudio.Shared/Resources/Strings/AppResources*.{cs,resx}` + `VocabQuiz.razor` + `docs/coresync-suspected-defects.md` under stash message `kaylee-stream-a-wip-vocab-quiz` before branching off `main`. Restore via `git checkout fix/vocab-quiz-ui-cluster-189-194 && git stash pop` when leaving Stream B.
+
+**Decision dropped:** `.squad/decisions/inbox/jayne-vocab-quiz-scoring-repro-189-191.md`.

--- a/.squad/agents/wash/history.md
+++ b/.squad/agents/wash/history.md
@@ -354,3 +354,7 @@ Turn 5 vs turn 6. Held proposal at turn 5 because it's the smallest change that 
 - **Filed:** `Tier2_TriggerRequiresBothMasteryAndStreak` (new) and `Tier2_MidMastery_BlockedByLowSessionCorrect` (renamed from `Tier2_MidMastery_NotEnoughTotal`) lock in the AND-trigger and (4,2) floor behavior.
 - **Skipped:** Mac Catalyst smoke (proposal + simulator + unit tests + Jayne's repro all green; flagged in PR description as recommended manual verification before merge).
 - **Out-of-scope follow-up to file:** decouple `MasteryScore` from `SessionRotationReady` (tutor's higher-leverage architectural suggestion). Mentioned in PR description.
+
+### Step 3 cross-link (2025-04-29, post-merge)
+- PR #198 body updated: out-of-scope follow-up now concretely references #197 (decouple `MasteryScore` from `SessionRotationReady`) instead of generic "follow-up issue".
+- Captain note: `MakeAttempt` test helper not setting `DifficultyWeight` (so Text weight 1.5x is bypassed in tests) is logged here and may be picked up either as a tiny standalone cleanup PR or folded into #197's acceptance criteria — Captain's call.

--- a/.squad/agents/wash/history.md
+++ b/.squad/agents/wash/history.md
@@ -343,3 +343,14 @@ Turn 5 vs turn 6. Held proposal at turn 5 because it's the smallest change that 
 - Legacy obsolete field WRITES in ProgressService — leave alone (sync compat).
 - Schema — no change.
 - Wrong-answer path — out of scope for #191.
+
+### Stream B Step 3 — Shipped #191 fix (2025-04-29)
+- **PR:** https://github.com/davidortinau/SentenceStudio/pull/198 (base: `main`, head: `fix/vocab-quiz-scoring-191-rotation-curve`, branched off Jayne's PR #195).
+- **Commit:** `70feb11` — `fix(vocab-quiz): tighten rotation curve for fresh words (#191)` — 9 files changed (+264 / -52).
+- **Production edits:** 2 lines as approved by Captain — `EFFECTIVE_STREAK_DIVISOR 7.0f → 12.0f` (`VocabularyProgressService.cs:21`) and Tier 2 `OR→AND` + floor `(2,1)→(4,2)` (`VocabularyQuizItem.cs:33-55`). Detailed comment blocks reference proposal markdown and simulator.
+- **Tests:** 520/520 pass. Jayne's `Repro191_NewWord_AllCorrect_DoesNotRotateOutBeforeFifthTurn` flipped FAIL → PASS as predicted.
+- **Test sweep gotcha (note for future):** Production code defaults `DifficultyWeight` to `1.0f` for ALL inputs (line 143) — Text attempts do NOT carry a 1.5x weight via the test's `MakeAttempt` helper because `DifficultyWeight` isn't set there. Initial test bumps assumed Text=1.5 weight; corrected by bumping MC counts from 5/7 → 8 across `MasteryAlgorithmIntegrationTests` (`FullLifecycle_Unknown_To_Learning_To_Known`, `FullLifecycle_KnownWord_GetsLongReviewInterval`, `WrongAnswer_AfterBuildingMastery_DropsBelowKnown`), `SpacedRepetitionIntegrationTests.KnownWord_HasReviewIn60Days_AfterAllAttempts`, `PlanToProgressLifecycleTests.FullCycle_PlanGeneration_ThenPractice`, and `MultiDayLearningJourneyTests.SimulateMultipleDays_MasteryProgressesCorrectly`.
+- **Simulator committed:** `tools/quiz-rotation-sim/sim.py` — Python-only repro of the C# math. Useful for any future tuning.
+- **Filed:** `Tier2_TriggerRequiresBothMasteryAndStreak` (new) and `Tier2_MidMastery_BlockedByLowSessionCorrect` (renamed from `Tier2_MidMastery_NotEnoughTotal`) lock in the AND-trigger and (4,2) floor behavior.
+- **Skipped:** Mac Catalyst smoke (proposal + simulator + unit tests + Jayne's repro all green; flagged in PR description as recommended manual verification before merge).
+- **Out-of-scope follow-up to file:** decouple `MasteryScore` from `SessionRotationReady` (tutor's higher-leverage architectural suggestion). Mentioned in PR description.

--- a/.squad/agents/wash/history.md
+++ b/.squad/agents/wash/history.md
@@ -304,3 +304,42 @@ Dashboard polls `/health` aggressively (every few seconds). Without the 30 s cac
 - `Aspire.Npgsql.EntityFrameworkCore.PostgreSQL` doesn't auto-map `/health`; the API's `ServiceDefaults` is intentionally MAUI-safe and skips `MapDefaultEndpoints`. Adding `app.MapHealthChecks("/health")` is the minimal incantation needed to surface health checks in the Aspire dashboard. Don't assume `MapDefaultEndpoints` exists on every Aspire app — check `ServiceDefaults/Extensions.cs` before relying on it.
 - `db.Database.GetDbConnection().DataSource` returns the `host:port` for Npgsql connections — handy for diagnostics without parsing the raw connection string and risking a credential leak.
 - Aspire's resource name (e.g. `db-84833ad0`) carries the AppHost path hash. Captain's main worktree currently binds `db-84833ad0`; a fresh worktree would bind a different suffix. The startup banner can't read the AppHost-side resource name directly, but `ASPIRE_RESOURCE_NAME` / `OTEL_SERVICE_INSTANCE_ID` env vars (when populated) carry enough signal — `EmptyUsersDetector.TryReadVolumeHashHint` surfaces whichever is set.
+
+## Stream B Step 2 — Vocab Quiz Scoring Proposal (#191)
+
+**Date:** 2025-01 (this turn)
+**Mode:** Investigation + proposal only. No production code touched.
+**Output:** `.squad/decisions/inbox/wash-vocab-quiz-scoring-proposal-191.md` (gitignored — Captain review)
+
+### What I investigated
+- `VocabularyQuizItem.ReadyToRotateOut` (lines 33–55). Tier 2 trigger is `OR` (`mastery>=0.5 OR streak>=3`) and the floor is just `SessC>=2 AND ST>=1`. This is the leak.
+- Per-turn mastery delta. **Important correction:** the writer is `VocabularyProgressService.RecordAttemptAsync` at `src/SentenceStudio.Shared/Services/VocabularyProgressService.cs:119-180`, NOT `ProgressService.cs` (that file only handles aggregate dashboard math). Constants live at lines 18-28; `EFFECTIVE_STREAK_DIVISOR = 7.0f`. The correct path is just `streak += weight; if production: prodInStreak++; mastery = max(eff/divisor, mastery) + recoveryBoost`.
+- Mode rule from `VocabQuiz.razor` `ChooseInteractionMode`: `streak>=3 OR mastery>=0.5 → Text` (mirrored in Jayne's test helper).
+- Confirmed Jayne's "rotation at turn 4" finding via simulator + by-hand math.
+
+### Simulator
+Built `tools/quiz-rotation-sim/sim.py` (~110 lines, stdlib only). Reproduces C# math verbatim. Walks fresh + half-mastered + already-known words for 12 turns under both rules. Captain or anyone can re-run.
+
+### Proposed rule (one rotation change + one delta change)
+- `ReadyToRotateOut` Tier 2: `OR` → `AND`, floor `(2,1)` → `(4,2)`.
+- `EFFECTIVE_STREAK_DIVISOR`: `7.0f` → `12.0f`.
+
+### Headline numbers
+| Scenario | Current | Proposed |
+|---|---|---|
+| Fresh word, all correct | rotates **turn 4** | rotates **turn 5** ✅ passes Jayne's `>=5` |
+| Half-mastered (m=0.5, s=3) | rotates turn 2 | rotates turn 4 |
+| Already-known (m=0.85) | rotates turn 1 | rotates turn 1 (UNCHANGED — no regression) |
+
+### Files I would edit if approved (post-Captain-review)
+- `src/SentenceStudio.Shared/Services/VocabularyProgressService.cs:21` (divisor const)
+- `src/SentenceStudio.Shared/Models/VocabularyQuizItem.cs:33-55` (Tier 2 predicate)
+- ~10 test methods across 4 test files (mechanical expected-value updates)
+
+### Captain's open question I flagged
+Turn 5 vs turn 6. Held proposal at turn 5 because it's the smallest change that passes Jayne. If Captain wants stricter, raise Tier 2 floor to `(5,3)` → turn 6 without touching the divisor.
+
+### Captain confirmed (do not touch)
+- Legacy obsolete field WRITES in ProgressService — leave alone (sync compat).
+- Schema — no change.
+- Wrong-answer path — out of scope for #191.

--- a/src/SentenceStudio.Shared/Models/VocabularyQuizItem.cs
+++ b/src/SentenceStudio.Shared/Models/VocabularyQuizItem.cs
@@ -31,6 +31,17 @@ public class VocabularyQuizItem
     public bool IsDueOnlySession { get; set; }
 
     // Tiered rotation model (spec §1.2.2 / §1.3)
+    //
+    // Issue #191: Tier 2 trigger tightened from OR → AND, and demonstration
+    // floor raised from (SessC≥2, ST≥1) to (SessC≥4, ST≥2). Under the old
+    // OR-trigger, a fresh word's first three correct MC turns alone (streak=3)
+    // dropped it from the strict Tier 3 floor into Tier 2's lenient floor,
+    // and the very next Text turn satisfied (2,1) — rotating fresh words at
+    // turn 4. The AND trigger keeps Tier 2 reserved for words that have BOTH
+    // accumulated mid-mastery AND a real streak, and the higher floor demands
+    // visible session-level demonstration. See:
+    //   .squad/decisions/inbox/wash-vocab-quiz-scoring-proposal-191.md
+    //   tools/quiz-rotation-sim/sim.py
     public bool ReadyToRotateOut
     {
         get
@@ -40,13 +51,14 @@ public class VocabularyQuizItem
 
             bool tieredReady;
 
-            // Tier 1: High mastery — 1 correct text + recognition cleared
+            // Tier 1: High mastery — 1 correct text + recognition cleared (UNCHANGED)
             if (mastery >= 0.80f || streak >= 8f)
                 tieredReady = SessionTextCorrect >= 1 && !PendingRecognitionCheck;
-            // Tier 2: Mid mastery — 2 correct (at least 1 text)
-            else if (mastery >= 0.50f || streak >= 3f)
-                tieredReady = SessionCorrectCount >= 2 && SessionTextCorrect >= 1;
-            // Tier 3: Low mastery — full 3+3 demonstration
+            // Tier 2: Mid mastery — must demonstrate BOTH mid-mastery AND streak,
+            // then prove with 4 in-session corrects including 2 text. (#191)
+            else if (mastery >= 0.50f && streak >= 3f)
+                tieredReady = SessionCorrectCount >= 4 && SessionTextCorrect >= 2;
+            // Tier 3: Low mastery — full 3+3 demonstration (UNCHANGED)
             else
                 tieredReady = SessionMCCorrect >= 3 && SessionTextCorrect >= 3;
 

--- a/src/SentenceStudio.Shared/Services/VocabularyProgressService.cs
+++ b/src/SentenceStudio.Shared/Services/VocabularyProgressService.cs
@@ -18,7 +18,13 @@ public class VocabularyProgressService : IVocabularyProgressService
     // NEW: Streak-based scoring constants
     private const float MASTERY_THRESHOLD = 0.85f;                // MasteryScore threshold for "Known"
     private const int MIN_PRODUCTION_FOR_KNOWN = 2;               // Minimum production attempts to be "Known"
-    private const float EFFECTIVE_STREAK_DIVISOR = 7.0f;          // EffectiveStreak / 7.0 = MasteryScore (capped at 1.0)
+    // Issue #191: divisor raised 7.0 → 12.0 so a fresh, all-correct word
+    // doesn't reach mastery 1.0 in 5 turns. With 12.0, an all-correct fresh
+    // word lands at mastery ≈ 0.583 by turn 5 and ≈ 0.917 by turn 7, aligning
+    // mastery growth with the rotation gate in VocabularyQuizItem.ReadyToRotateOut.
+    // See .squad/decisions/inbox/wash-vocab-quiz-scoring-proposal-191.md and
+    // tools/quiz-rotation-sim/sim.py for the simulation that justifies this value.
+    private const float EFFECTIVE_STREAK_DIVISOR = 12.0f;         // EffectiveStreak / 12.0 = MasteryScore (capped at 1.0)
 
     // Phase 0: Scoring engine constants
     private const float WRONG_ANSWER_FLOOR = 0.6f;               // Scaled penalty never softer than this

--- a/tests/SentenceStudio.UnitTests/Integration/MasteryAlgorithmIntegrationTests.cs
+++ b/tests/SentenceStudio.UnitTests/Integration/MasteryAlgorithmIntegrationTests.cs
@@ -61,8 +61,8 @@ public class MasteryAlgorithmIntegrationTests : IClassFixture<PlanGenerationTest
         result.ProductionInStreak.Should().Be(0, "MultipleChoice is not production");
         result.TotalAttempts.Should().Be(1);
         result.CorrectAttempts.Should().Be(1);
-        // EffectiveStreak = 1 + 0*0.5 = 1.0 → MasteryScore = 1.0/7.0 ≈ 0.143
-        result.MasteryScore.Should().BeApproximately(1.0f / 7.0f, 0.01f);
+        // EffectiveStreak = 1 + 0*0.5 = 1.0 → MasteryScore = 1.0/12.0 ≈ 0.083 (#191)
+        result.MasteryScore.Should().BeApproximately(1.0f / 12.0f, 0.01f);
         result.IsKnown.Should().BeFalse("one correct answer is not enough");
         result.Status.Should().Be(LearningStatus.Learning);
     }
@@ -81,8 +81,8 @@ public class MasteryAlgorithmIntegrationTests : IClassFixture<PlanGenerationTest
         // Assert
         result.CurrentStreak.Should().Be(1);
         result.ProductionInStreak.Should().Be(1, "Text input is production");
-        // EffectiveStreak = 1 + 1*0.5 = 1.5 → MasteryScore = 1.5/7.0 ≈ 0.214
-        result.MasteryScore.Should().BeApproximately(1.5f / 7.0f, 0.01f);
+        // EffectiveStreak = 1 + 1*0.5 = 1.5 → MasteryScore = 1.5/12.0 ≈ 0.125 (#191)
+        result.MasteryScore.Should().BeApproximately(1.5f / 12.0f, 0.01f);
     }
 
     [Fact]
@@ -118,24 +118,26 @@ public class MasteryAlgorithmIntegrationTests : IClassFixture<PlanGenerationTest
     }
 
     [Fact]
-    public async Task RecordAttempt_StreakOf7Recognition_ReachesMasteryThresholdButNotKnown()
+    public async Task RecordAttempt_StreakOf12Recognition_ReachesMasteryCapButNotKnown()
     {
-        // Arrange: 7 consecutive correct MC answers
+        // Arrange: 12 consecutive correct MC answers — saturates the new
+        // EFFECTIVE_STREAK_DIVISOR=12.0 ceiling (#191).
         var resource = _fixture.SeedResource(vocabWordCount: 1);
         var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
 
-        // Act: 7 correct recognition attempts
+        // Act: 12 correct recognition attempts
         VocabularyProgress? result = null;
-        for (int i = 0; i < 7; i++)
+        for (int i = 0; i < 12; i++)
         {
             result = await _progressService.RecordAttemptAsync(
                 MakeAttempt(wordId, wasCorrect: true, inputMode: "MultipleChoice"));
         }
 
         // Assert
-        result!.CurrentStreak.Should().BeApproximately(7.0f, 0.01f);
+        result!.CurrentStreak.Should().BeApproximately(12.0f, 0.01f);
         result.ProductionInStreak.Should().Be(0);
-        // EffectiveStreak = 7 + 0 = 7 → MasteryScore = 7/7 = 1.0
+        // EffectiveStreak = 12 + 0 = 12 → MasteryScore = 12/12 = 1.0
+        // (recovery boost may push slightly above 1.0 but is clamped)
         result.MasteryScore.Should().Be(1.0f);
         result.IsKnown.Should().BeFalse(
             "IsKnown requires ProductionInStreak >= 2 even with max mastery score");
@@ -159,15 +161,18 @@ public class MasteryAlgorithmIntegrationTests : IClassFixture<PlanGenerationTest
             "after first attempt, word should be Learning");
         progress.IsKnown.Should().BeFalse();
 
-        // Phase 2: Build up recognition streak (MC only)
-        for (int i = 0; i < 4; i++)
+        // Phase 2: Build up recognition streak (MC only) — under #191's
+        // EFFECTIVE_STREAK_DIVISOR=12.0, need 7 MC to clear the 0.50 promotion
+        // threshold (was 4 under divisor 7.0). We do 8 here so the final
+        // 8 MC + 2 Text combo lands at mastery >= 0.85 for IsKnown.
+        for (int i = 0; i < 7; i++)
         {
             progress = await _progressService.RecordAttemptAsync(
                 MakeAttempt(wordId, wasCorrect: true, inputMode: "MultipleChoice"));
         }
-        // After 5 MC: EffStreak = 5/7 ≈ 0.71 → should be above promotion threshold (0.50)
+        // After 8 MC: EffStreak = 8/12 ≈ 0.667 → above promotion threshold (0.50)
         progress.MasteryScore.Should().BeGreaterOrEqualTo(0.50f,
-            "after 5 correct MC answers, should be above promotion threshold");
+            "after 8 correct MC answers, should be above promotion threshold");
         progress.IsKnown.Should().BeFalse("still no production attempts");
 
         // Phase 3: Switch to production mode (Text input)
@@ -180,7 +185,8 @@ public class MasteryAlgorithmIntegrationTests : IClassFixture<PlanGenerationTest
             MakeAttempt(wordId, wasCorrect: true, inputMode: "Text"));
         progress.ProductionInStreak.Should().Be(2);
 
-        // EffStreak = 7 + 2*0.5 = 8 → Mastery = min(8/7, 1.0) = 1.0
+        // After 8 MC + 2 Text: streak = 10, prodInStreak = 2,
+        // EffStreak = 10 + 2*0.5 = 11 → Mastery = 11/12 ≈ 0.917
         progress.MasteryScore.Should().BeGreaterOrEqualTo(0.85f);
         progress.IsKnown.Should().BeTrue(
             "MasteryScore >= 0.85 AND ProductionInStreak >= 2 → Known");
@@ -195,8 +201,8 @@ public class MasteryAlgorithmIntegrationTests : IClassFixture<PlanGenerationTest
         var resource = _fixture.SeedResource(vocabWordCount: 1);
         var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
 
-        // 5 MC + 2 Text = Known
-        for (int i = 0; i < 5; i++)
+        // 8 MC + 2 Text = Known (divisor 12.0 — #191: streak=10, prodIn=2, eff=11, mastery≈0.917)
+        for (int i = 0; i < 8; i++)
             await _progressService.RecordAttemptAsync(
                 MakeAttempt(wordId, wasCorrect: true, inputMode: "MultipleChoice"));
         for (int i = 0; i < 2; i++)
@@ -219,8 +225,8 @@ public class MasteryAlgorithmIntegrationTests : IClassFixture<PlanGenerationTest
         var resource = _fixture.SeedResource(vocabWordCount: 1);
         var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
 
-        // 4 MC + 2 Text
-        for (int i = 0; i < 4; i++)
+        // 8 MC + 2 Text (divisor 12.0 — #191: drives word to Known before wrong answer)
+        for (int i = 0; i < 8; i++)
             await _progressService.RecordAttemptAsync(
                 MakeAttempt(wordId, wasCorrect: true, inputMode: "MultipleChoice"));
         for (int i = 0; i < 2; i++)
@@ -252,13 +258,13 @@ public class MasteryAlgorithmIntegrationTests : IClassFixture<PlanGenerationTest
     [Fact]
     public async Task IsPromoted_SetAt50PercentMastery()
     {
-        // Arrange: need EffectiveStreak >= 3.5 for MasteryScore >= 0.50
-        // 4 MC: EffStreak = 4/7 ≈ 0.57 → above 0.50
+        // Arrange: under #191's EFFECTIVE_STREAK_DIVISOR=12.0, need EffectiveStreak >= 6
+        // for MasteryScore >= 0.50. 6 MC: EffStreak = 6/12 = 0.50 → exactly at promotion floor.
         var resource = _fixture.SeedResource(vocabWordCount: 1);
         var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
 
         VocabularyProgress? result = null;
-        for (int i = 0; i < 4; i++)
+        for (int i = 0; i < 6; i++)
         {
             result = await _progressService.RecordAttemptAsync(
                 MakeAttempt(wordId, wasCorrect: true, inputMode: "MultipleChoice"));
@@ -273,7 +279,7 @@ public class MasteryAlgorithmIntegrationTests : IClassFixture<PlanGenerationTest
     [Fact]
     public async Task NotPromoted_Below50PercentMastery()
     {
-        // Arrange: 2 MC: EffStreak = 2/7 ≈ 0.286 → below 0.50
+        // Arrange: 2 MC under divisor 12.0: EffStreak = 2/12 ≈ 0.167 → below 0.50 (#191)
         var resource = _fixture.SeedResource(vocabWordCount: 1);
         var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
 
@@ -320,7 +326,7 @@ public class MasteryAlgorithmIntegrationTests : IClassFixture<PlanGenerationTest
         var resource = _fixture.SeedResource(vocabWordCount: 1);
         var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
 
-        // 10 Text attempts: EffStreak = 10 + 10*0.5 = 15 → 15/7 = 2.14, capped at 1.0
+        // 10 Text attempts: EffStreak = 10*1.5 + 10*0.5 = 20 → 20/12 ≈ 1.67, capped at 1.0 (#191)
         for (int i = 0; i < 10; i++)
         {
             await _progressService.RecordAttemptAsync(
@@ -350,7 +356,8 @@ public class MasteryAlgorithmIntegrationTests : IClassFixture<PlanGenerationTest
 
         var result = await _progressService.GetProgressAsync(wordId, PlanGenerationTestFixture.TestUserId);
         // Phase 0: scaled penalty is softer (~0.83x per wrong for 3 correct attempts)
-        // After 3 correct: mastery ≈ 0.429, then 5 wrongs at ~0.83x each ≈ 0.17
+        // Under divisor 12.0 (#191): after 3 correct: mastery ≈ 0.25,
+        // then 5 wrongs at ~0.83x each ≈ 0.10
         result.MasteryScore.Should().BeLessThan(0.25f,
             "multiple penalties should drive mastery down significantly");
         result.MasteryScore.Should().BeGreaterOrEqualTo(0f, "mastery should not go negative");

--- a/tests/SentenceStudio.UnitTests/Integration/MultiDayLearningJourneyTests.cs
+++ b/tests/SentenceStudio.UnitTests/Integration/MultiDayLearningJourneyTests.cs
@@ -186,20 +186,20 @@ public class MultiDayLearningJourneyTests : IClassFixture<PlanGenerationTestFixt
             }
         }
 
-        // After Day 1: all words at ~0.286 mastery (EffStreak=2/7)
+        // After Day 1: all words at ~0.167 mastery (EffStreak=2, divisor 12.0 — #191)
         foreach (var wordId in wordIds)
         {
             var p = await _progressService.GetProgressAsync(wordId, PlanGenerationTestFixture.TestUserId);
-            p.MasteryScore.Should().BeApproximately(2.0f / 7.0f, 0.01f);
+            p.MasteryScore.Should().BeApproximately(2.0f / 12.0f, 0.01f);
             p.IsKnown.Should().BeFalse();
             p.Status.Should().Be(LearningStatus.Learning);
         }
 
         // === Day 2: More MC practice, some words get a wrong answer ===
-        // First 4 words: 2 more correct MC (total streak 4, mastery ≈ 0.57)
+        // First 4 words: 6 more correct MC (total streak 8, mastery ≈ 0.667 — #191)
         for (int w = 0; w < 4; w++)
         {
-            for (int i = 0; i < 2; i++)
+            for (int i = 0; i < 6; i++)
             {
                 await _progressService.RecordAttemptAsync(new VocabularyAttempt
                 {
@@ -233,8 +233,8 @@ public class MultiDayLearningJourneyTests : IClassFixture<PlanGenerationTestFixt
         for (int w = 0; w < 4; w++)
         {
             var p = await _progressService.GetProgressAsync(wordIds[w], PlanGenerationTestFixture.TestUserId);
-            p.CurrentStreak.Should().BeApproximately(4.0f, 0.01f, $"word {w} should have 4-streak after 4 correct MC");
-            p.MasteryScore.Should().BeApproximately(4.0f / 7.0f, 0.01f);
+            p.CurrentStreak.Should().BeApproximately(8.0f, 0.01f, $"word {w} should have 8-streak after 8 correct MC");
+            p.MasteryScore.Should().BeApproximately(8.0f / 12.0f, 0.01f);
         }
         for (int w = 4; w < 6; w++)
         {
@@ -261,11 +261,11 @@ public class MultiDayLearningJourneyTests : IClassFixture<PlanGenerationTestFixt
             }
         }
 
-        // Words 0-3: streak 6, productionInStreak 2, EffStreak = 6+1 = 7 → mastery 1.0
+        // Words 0-3: streak 8+(2*1.0)=10, prodInStreak 2, EffStreak = 10+1 = 11 → mastery = 11/12 ≈ 0.917 (#191)
         for (int w = 0; w < 4; w++)
         {
             var p = await _progressService.GetProgressAsync(wordIds[w], PlanGenerationTestFixture.TestUserId);
-            p.CurrentStreak.Should().BeApproximately(6.0f, 0.01f);
+            p.CurrentStreak.Should().BeApproximately(10.0f, 0.01f);
             p.ProductionInStreak.Should().Be(2);
             p.MasteryScore.Should().BeGreaterOrEqualTo(0.85f);
             p.IsKnown.Should().BeTrue(
@@ -277,7 +277,7 @@ public class MultiDayLearningJourneyTests : IClassFixture<PlanGenerationTestFixt
         for (int w = 6; w < 8; w++)
         {
             var p = await _progressService.GetProgressAsync(wordIds[w], PlanGenerationTestFixture.TestUserId);
-            p.MasteryScore.Should().BeApproximately(2.0f / 7.0f, 0.01f);
+            p.MasteryScore.Should().BeApproximately(2.0f / 12.0f, 0.01f);
             p.IsKnown.Should().BeFalse();
         }
 

--- a/tests/SentenceStudio.UnitTests/Integration/PlanToProgressLifecycleTests.cs
+++ b/tests/SentenceStudio.UnitTests/Integration/PlanToProgressLifecycleTests.cs
@@ -80,10 +80,10 @@ public class PlanToProgressLifecycleTests : IClassFixture<PlanGenerationTestFixt
         var dueCountBefore = plan1.VocabularyReview!.TotalDue;
         dueCountBefore.Should().BeGreaterOrEqualTo(5, "should have substantial due words");
 
-        // === STEP 2: Simulate practice — first 5 words get 5 MC + 2 Text each → Known ===
+        // === STEP 2: Simulate practice — first 5 words get 8 MC + 2 Text each → Known (divisor 12.0 — #191) ===
         for (int w = 0; w < 5; w++)
         {
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < 8; i++)
             {
                 await _progressService.RecordAttemptAsync(new VocabularyAttempt
                 {
@@ -117,7 +117,7 @@ public class PlanToProgressLifecycleTests : IClassFixture<PlanGenerationTestFixt
         for (int w = 0; w < 5; w++)
         {
             var p = await _progressService.GetProgressAsync(wordIds[w], PlanGenerationTestFixture.TestUserId);
-            p.IsKnown.Should().BeTrue($"word {w} should be Known after 5 MC + 2 Text");
+            p.IsKnown.Should().BeTrue($"word {w} should be Known after 8 MC + 2 Text");
         }
 
         // Words 5-9 still at original level

--- a/tests/SentenceStudio.UnitTests/Integration/SpacedRepetitionIntegrationTests.cs
+++ b/tests/SentenceStudio.UnitTests/Integration/SpacedRepetitionIntegrationTests.cs
@@ -299,8 +299,8 @@ public class SpacedRepetitionIntegrationTests : IClassFixture<PlanGenerationTest
         var resource = _fixture.SeedResource(vocabWordCount: 1);
         var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
 
-        // 5 MC + 2 Text → Known
-        for (int i = 0; i < 5; i++)
+        // 8 MC + 2 Text → Known (divisor 12.0 — #191)
+        for (int i = 0; i < 8; i++)
             await _progressService.RecordAttemptAsync(
                 MakeAttempt(wordId, wasCorrect: true, inputMode: "MultipleChoice"));
         for (int i = 0; i < 2; i++)

--- a/tests/SentenceStudio.UnitTests/Integration/VocabQuizScoringRepro189And191Tests.cs
+++ b/tests/SentenceStudio.UnitTests/Integration/VocabQuizScoringRepro189And191Tests.cs
@@ -1,0 +1,352 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SentenceStudio.Data;
+using SentenceStudio.Services;
+using SentenceStudio.Shared.Models;
+using SentenceStudio.UnitTests.PlanGeneration;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SentenceStudio.UnitTests.Integration;
+
+/// <summary>
+/// Failing repro tests for the Vocabulary Quiz scoring bugs identified by Captain
+/// in issues #189 and #191. Author: Jayne (Tester) — Stream B Step 1.
+///
+/// These tests exist to:
+///   1. Pin down the EXPECTED post-state of VocabularyProgress after well-defined
+///      quiz interactions, so Wash has unambiguous targets to fix against.
+///   2. Disambiguate competing hypotheses for #189 (service double-increment vs
+///      UI panel reading legacy obsolete fields).
+///   3. Expose how aggressively new words rotate out today (#191), so the team
+///      can decide on a corrected curve.
+///
+/// Tests use the same in-memory SQLite + real EF Core fixture as
+/// <see cref="MasteryAlgorithmIntegrationTests"/>, so the failure signatures
+/// reflect production code paths, not mocks.
+/// </summary>
+public class VocabQuizScoringRepro189And191Tests
+    : IClassFixture<PlanGenerationTestFixture>, IDisposable
+{
+    private readonly PlanGenerationTestFixture _fixture;
+    private readonly VocabularyProgressService _progressService;
+    private readonly ITestOutputHelper _output;
+
+    public VocabQuizScoringRepro189And191Tests(
+        PlanGenerationTestFixture fixture,
+        ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+        _fixture.ClearAllData();
+        _fixture.SeedUserProfile();
+
+        var scope = fixture.ServiceProvider.CreateScope();
+        var progressRepo = scope.ServiceProvider.GetRequiredService<VocabularyProgressRepository>();
+        var contextRepo = new VocabularyLearningContextRepository(
+            fixture.ServiceProvider,
+            scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<VocabularyLearningContextRepository>());
+
+        _progressService = new VocabularyProgressService(
+            progressRepo,
+            contextRepo,
+            scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<VocabularyProgressService>(),
+            fixture.ServiceProvider);
+    }
+
+    public void Dispose() { }
+
+    // ---------------------------------------------------------------------
+    // #189 — Attempt counting / accuracy correctness
+    // ---------------------------------------------------------------------
+    //
+    // Captain's report: After ONE correct recognition turn on the word 털,
+    // the Learning Details panel shows "2 production attempts / 50% accuracy".
+    //
+    // Two competing hypotheses:
+    //   (a) ProgressService is double-incrementing on a single attempt.
+    //   (b) The Learning Details panel is reading legacy obsolete fields
+    //       that don't match the new streak-based truth.
+    //
+    // This test asserts the EXPECTED post-state per the bug report. If it
+    // FAILS, hypothesis (a) is correct — the service is buggy. If it PASSES,
+    // hypothesis (b) is correct — the bug is purely in the UI panel reading
+    // wrong fields, and the panel needs to be fixed (not the service).
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task Repro189_SingleCorrectRecognitionAttempt_ProducesExpectedPanelState()
+    {
+        // Arrange — a brand-new word with no prior progress, mimicking 털.
+        var resource = _fixture.SeedResource(vocabWordCount: 1);
+        var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
+
+        var attempt = MakeRecognitionAttempt(wordId, wasCorrect: true);
+
+        // Act — one correct multiple-choice (recognition) turn, exactly as the
+        // quiz issues via VocabQuiz.razor → ProgressService.RecordAttemptAsync.
+        var result = await _progressService.RecordAttemptAsync(attempt);
+
+        // Dump the row for the PR description so Wash sees the actual values.
+        _output.WriteLine(DumpProgress(result));
+
+        // Assert — every field the Learning Details panel reads must match the
+        // narrative of "ONE correct recognition turn".
+        using (new FluentAssertions.Execution.AssertionScope())
+        {
+            // Core counters (panel rows TotalAttempts / CorrectAttempts / Accuracy).
+            result.TotalAttempts.Should().Be(1,
+                "exactly one attempt was recorded");
+            result.CorrectAttempts.Should().Be(1,
+                "the single attempt was correct");
+            result.Accuracy.Should().Be(1.0f,
+                "1 correct ÷ 1 total = 100%, NOT the 50% Captain reported");
+
+            // Streak fields (panel rows CurrentStreak / ProductionInStreak).
+            result.CurrentStreak.Should().Be(1f,
+                "one correct MC at DifficultyWeight=1.0 yields streak 1");
+            result.ProductionInStreak.Should().Be(0,
+                "MultipleChoice is recognition, not production — must NOT be 2");
+
+            // Legacy obsolete fields — must not be incremented as production.
+#pragma warning disable CS0618
+            result.RecognitionAttempts.Should().Be(1,
+                "Phase=Recognition for InputMode=MultipleChoice");
+            result.RecognitionCorrect.Should().Be(1);
+            result.ProductionAttempts.Should().Be(0,
+                "no production attempts occurred");
+            result.ProductionCorrect.Should().Be(0);
+            result.ApplicationAttempts.Should().Be(0);
+            result.ApplicationCorrect.Should().Be(0);
+#pragma warning restore CS0618
+        }
+    }
+
+    /// <summary>
+    /// Companion test for #189: belt-and-suspenders assertion that a single
+    /// recognition (MultipleChoice) attempt does not touch any obsolete
+    /// production-side counter. If this test passes today (which the service
+    /// code suggests it will), the bug is in the panel layer — the panel must
+    /// stop displaying these legacy fields and read only the streak-based
+    /// truth.
+    /// </summary>
+    [Fact]
+    public async Task Repro189_SingleCorrectRecognition_LegacyProductionFieldsRemainZero()
+    {
+        var resource = _fixture.SeedResource(vocabWordCount: 1);
+        var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
+
+        var result = await _progressService.RecordAttemptAsync(
+            MakeRecognitionAttempt(wordId, wasCorrect: true));
+
+        _output.WriteLine(DumpProgress(result));
+
+#pragma warning disable CS0618
+        result.ProductionAttempts.Should().Be(0,
+            "Phase derived from MultipleChoice is Recognition; ProductionAttempts must NEVER be incremented for an MC turn (#189)");
+        result.ProductionCorrect.Should().Be(0,
+            "ProductionCorrect must stay zero on a recognition-only turn (#189)");
+        result.ProductionAccuracy.Should().Be(0,
+            "ProductionAccuracy = ProductionCorrect/ProductionAttempts must be 0 with no production turns (#189)");
+#pragma warning restore CS0618
+    }
+
+    // ---------------------------------------------------------------------
+    // #191 — Latter quiz rounds rapidly empty
+    // ---------------------------------------------------------------------
+    //
+    // Captain's report: User mastered 26 new words in 58 turns over 8 rounds.
+    // Round 8 showed only 2 words — new words rotate out far too quickly.
+    //
+    // Hypothesis: VocabularyQuizItem.ReadyToRotateOut Tier 2
+    // (mastery >= 0.50 OR streak >= 3) lets a brand-new word rotate after
+    // only 2-3 correct MC turns followed by a single Text turn — far less
+    // demonstration than 8 rounds × ~7 turns implies.
+    //
+    // The walk below mimics VocabQuiz.razor's ChooseInteractionMode logic:
+    //   • Default mode is MultipleChoice.
+    //   • Mode flips to Text once CurrentStreak >= 3 OR MasteryScore >= 0.50.
+    // We simulate ALL CORRECT answers and record the first turn at which
+    // VocabularyQuizItem.ReadyToRotateOut becomes true.
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task Repro191_NewWord_AllCorrect_DoesNotRotateOutBeforeFifthTurn()
+    {
+        // Arrange — one fresh word, no prior progress.
+        var resource = _fixture.SeedResource(vocabWordCount: 1);
+        var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
+        var word = SeedWordReference(wordId);
+
+        var quizItem = new VocabularyQuizItem
+        {
+            Word = word,
+            Progress = await _progressService.GetProgressAsync(wordId),
+            IsCurrent = true,
+        };
+
+        // Walk — at most 8 turns of all-correct answers, mirroring the quiz's
+        // mode-selection rule. Track ReadyToRotateOut at each turn boundary.
+        const int maxTurns = 8;
+        int? firstRotateTurn = null;
+        var trace = new List<string>();
+
+        for (int turn = 1; turn <= maxTurns; turn++)
+        {
+            // Replicate VocabQuiz.razor mode-selection from the current Progress.
+            string mode = ChooseQuizModeForTurn(quizItem);
+            float weight = mode == "Text" ? 1.5f : 1.0f;
+
+            var attempt = new VocabularyAttempt
+            {
+                VocabularyWordId = wordId,
+                UserId = PlanGenerationTestFixture.TestUserId,
+                Activity = "VocabularyQuiz",
+                InputMode = mode,
+                ContextType = "Isolated",
+                WasCorrect = true,
+                DifficultyWeight = weight,
+                ResponseTimeMs = 1500
+            };
+
+            quizItem.Progress = await _progressService.RecordAttemptAsync(attempt);
+
+            // Mirror the per-turn session counter bumps from VocabQuiz.razor.
+            quizItem.SessionCorrectCount++;
+            if (mode == "MultipleChoice") quizItem.SessionMCCorrect++;
+            else quizItem.SessionTextCorrect++;
+
+            trace.Add(
+                $"turn={turn} mode={mode} streak={quizItem.Progress.CurrentStreak:F2} "
+              + $"prodInStreak={quizItem.Progress.ProductionInStreak} "
+              + $"mastery={quizItem.Progress.MasteryScore:F3} "
+              + $"sessMC={quizItem.SessionMCCorrect} sessText={quizItem.SessionTextCorrect} "
+              + $"ReadyToRotateOut={quizItem.ReadyToRotateOut}");
+
+            if (quizItem.ReadyToRotateOut && firstRotateTurn is null)
+                firstRotateTurn = turn;
+        }
+
+        foreach (var line in trace) _output.WriteLine(line);
+        _output.WriteLine($"First ReadyToRotateOut turn: {firstRotateTurn?.ToString() ?? "never"}");
+
+        // Assertion — Captain reported that 26 fresh words mastered in just
+        // 58 turns over 8 rounds is too aggressive. A brand-new word receiving
+        // ALL CORRECT answers should NOT yet be eligible for rotation by turn 4.
+        // The expected curve is TBD (Wash + Captain to define), but turn-4
+        // rotation is well below any reasonable mastery bar — failing here
+        // exposes that #191 is real.
+        firstRotateTurn.Should().BeGreaterOrEqualTo(5,
+            "a brand-new word with 4 all-correct turns demonstrates too little mastery "
+          + "to rotate out — current Tier 2 logic flips this at turn 4 (3 MC + 1 Text), "
+          + "which is the rapid-empty behavior #191 describes");
+    }
+
+    /// <summary>
+    /// Documents (without prescribing) the current rotation behavior so that
+    /// when Wash lands the fix, the diff in this number tells everyone the
+    /// curve actually changed. Passing test — pure characterization.
+    /// </summary>
+    [Fact]
+    public async Task Repro191_CharacterizeCurrentBehavior_FreshWordRotatesAtTurnN()
+    {
+        var resource = _fixture.SeedResource(vocabWordCount: 1);
+        var wordId = _fixture.GetResourceVocabularyWordIds(resource.Id).First();
+        var word = SeedWordReference(wordId);
+
+        var quizItem = new VocabularyQuizItem
+        {
+            Word = word,
+            Progress = await _progressService.GetProgressAsync(wordId),
+        };
+
+        int? firstRotateTurn = null;
+        for (int turn = 1; turn <= 12 && firstRotateTurn is null; turn++)
+        {
+            string mode = ChooseQuizModeForTurn(quizItem);
+            quizItem.Progress = await _progressService.RecordAttemptAsync(new VocabularyAttempt
+            {
+                VocabularyWordId = wordId,
+                UserId = PlanGenerationTestFixture.TestUserId,
+                Activity = "VocabularyQuiz",
+                InputMode = mode,
+                ContextType = "Isolated",
+                WasCorrect = true,
+                DifficultyWeight = mode == "Text" ? 1.5f : 1.0f,
+                ResponseTimeMs = 1500
+            });
+
+            quizItem.SessionCorrectCount++;
+            if (mode == "MultipleChoice") quizItem.SessionMCCorrect++;
+            else quizItem.SessionTextCorrect++;
+
+            if (quizItem.ReadyToRotateOut) firstRotateTurn = turn;
+        }
+
+        _output.WriteLine($"Characterization: fresh word with all-correct answers "
+            + $"first becomes ReadyToRotateOut at turn {firstRotateTurn?.ToString() ?? "never"}.");
+
+        firstRotateTurn.Should().NotBeNull(
+            "if rotation never happens, the test setup is wrong — a non-failing snapshot "
+          + "is fine here, but it must capture some turn number for the team to debate");
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static VocabularyAttempt MakeRecognitionAttempt(string wordId, bool wasCorrect) =>
+        new VocabularyAttempt
+        {
+            VocabularyWordId = wordId,
+            UserId = PlanGenerationTestFixture.TestUserId,
+            Activity = "VocabularyQuiz",
+            // VocabQuiz.razor sends the literal string "MultipleChoice"
+            // (not InputMode.MultipleChoice.ToString(), which happens to
+            // match) when userMode is the default for a fresh word.
+            InputMode = "MultipleChoice",
+            WasCorrect = wasCorrect,
+            DifficultyWeight = 1.0f,
+            ContextType = "Isolated",
+            ResponseTimeMs = 1500
+        };
+
+    /// <summary>
+    /// Mirror of VocabQuiz.razor's ChooseInteractionMode (lines 792-801):
+    ///   • PendingRecognitionCheck → MultipleChoice
+    ///   • CurrentStreak >= 3 OR MasteryScore >= 0.50 → Text
+    ///   • else → MultipleChoice
+    /// </summary>
+    private static string ChooseQuizModeForTurn(VocabularyQuizItem item)
+    {
+        if (item.PendingRecognitionCheck) return "MultipleChoice";
+        var streak = item.Progress?.CurrentStreak ?? 0f;
+        var mastery = item.Progress?.MasteryScore ?? 0f;
+        return (streak >= 3f || mastery >= 0.50f) ? "Text" : "MultipleChoice";
+    }
+
+    /// <summary>
+    /// Loads the seeded VocabularyWord row so VocabularyQuizItem has a
+    /// proper Word reference (required = constructor-init only).
+    /// </summary>
+    private VocabularyWord SeedWordReference(string wordId)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return db.VocabularyWords.AsQueryable().First(w => w.Id == wordId);
+    }
+
+    private static string DumpProgress(VocabularyProgress p)
+    {
+#pragma warning disable CS0618
+        return $"VocabularyProgress dump:\n"
+             + $"  TotalAttempts={p.TotalAttempts}, CorrectAttempts={p.CorrectAttempts}, Accuracy={p.Accuracy:F3}\n"
+             + $"  CurrentStreak={p.CurrentStreak:F2}, ProductionInStreak={p.ProductionInStreak}, MasteryScore={p.MasteryScore:F3}\n"
+             + $"  RecognitionAttempts={p.RecognitionAttempts}, RecognitionCorrect={p.RecognitionCorrect}\n"
+             + $"  ProductionAttempts={p.ProductionAttempts}, ProductionCorrect={p.ProductionCorrect}\n"
+             + $"  ApplicationAttempts={p.ApplicationAttempts}, ApplicationCorrect={p.ApplicationCorrect}\n"
+             + $"  IsKnown={p.IsKnown}, Status={p.Status}";
+#pragma warning restore CS0618
+    }
+}

--- a/tests/SentenceStudio.UnitTests/PlanGeneration/VocabQuizFilteringTests.cs
+++ b/tests/SentenceStudio.UnitTests/PlanGeneration/VocabQuizFilteringTests.cs
@@ -397,29 +397,53 @@ public class VocabQuizFilteringTests
     }
 
     [Fact]
-    public void Tier2_MidMastery_Rotates_2CorrectWith1Text()
+    public void Tier2_MidMastery_Rotates_4CorrectWith2Text()
     {
+        // #191: Tier 2 trigger now requires mastery>=0.50 AND streak>=3 (was OR),
+        // and floor raised from (SessC>=2, ST>=1) to (SessC>=4, ST>=2).
         var item = MakeQuizItem(new VocabularyProgress
         {
             MasteryScore = 0.55f, CurrentStreak = 4f
         });
-        item.SessionCorrectCount = 2;
-        item.SessionTextCorrect = 1;
+        item.SessionCorrectCount = 4;
+        item.SessionTextCorrect = 2;
 
-        item.ReadyToRotateOut.Should().BeTrue("Tier 2: 2 correct with 1 text");
+        item.ReadyToRotateOut.Should().BeTrue("Tier 2: 4 correct with 2 text (#191)");
     }
 
     [Fact]
-    public void Tier2_MidMastery_NotEnoughTotal()
+    public void Tier2_MidMastery_BlockedByLowSessionCorrect()
     {
+        // #191: under new floor (4 corr, 2 text), a fresh-Tier-2 word with only
+        // 3 corrects and 1 text must NOT rotate out.
         var item = MakeQuizItem(new VocabularyProgress
         {
             MasteryScore = 0.55f, CurrentStreak = 4f
         });
-        item.SessionCorrectCount = 1;
+        item.SessionCorrectCount = 3;
         item.SessionTextCorrect = 1;
 
-        item.ReadyToRotateOut.Should().BeFalse("Tier 2: only 1 correct total, need 2");
+        item.ReadyToRotateOut.Should().BeFalse(
+            "Tier 2: only 3 correct / 1 text, need 4 / 2 (#191)");
+    }
+
+    [Fact]
+    public void Tier2_TriggerRequiresBothMasteryAndStreak()
+    {
+        // #191: a fresh word that has hit streak>=3 but mastery<0.5 falls to
+        // Tier 3 (was Tier 2 under the old OR-trigger). Tier 3 requires the
+        // strict 3 MC + 3 Text demonstration, which is NOT met here.
+        var item = MakeQuizItem(new VocabularyProgress
+        {
+            MasteryScore = 0.30f, CurrentStreak = 4f
+        });
+        item.SessionCorrectCount = 4;
+        item.SessionTextCorrect = 2;
+        item.SessionMCCorrect = 2;
+
+        item.ReadyToRotateOut.Should().BeFalse(
+            "Tier 2 trigger now requires BOTH mastery>=0.5 AND streak>=3 — "
+          + "this word has streak but not mastery, so falls to Tier 3 (#191)");
     }
 
     [Fact]

--- a/tools/quiz-rotation-sim/sim.py
+++ b/tools/quiz-rotation-sim/sim.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Vocabulary Quiz rotation simulator — Wash, Stream B Step 2 (#191).
+
+Mirrors:
+  • VocabularyProgressService.RecordAttemptAsync correct-path math
+    (src/SentenceStudio.Shared/Services/VocabularyProgressService.cs:119-180)
+  • VocabularyQuizItem.ReadyToRotateOut tiered rule
+    (src/SentenceStudio.Shared/Models/VocabularyQuizItem.cs:33-55)
+  • VocabQuiz.razor mode selection (streak>=3 OR mastery>=0.50 → Text)
+
+Two rules implemented:
+  • CURRENT — production code today
+  • PROPOSED — Wash's proposal for #191
+
+Run: python3 sim.py
+"""
+from dataclasses import dataclass, field
+
+# --- Constants from VocabularyProgressService.cs ---
+CURRENT_DIVISOR = 7.0
+PROPOSED_DIVISOR = 12.0
+RECOVERY_BOOST = 0.02
+MC_WEIGHT = 1.0
+TEXT_WEIGHT = 1.5
+
+@dataclass
+class Item:
+    mastery: float = 0.0
+    streak: float = 0.0
+    prod_in_streak: int = 0
+    total: int = 0
+    correct: int = 0
+    sess_correct: int = 0
+    sess_mc: int = 0
+    sess_text: int = 0
+    pending_rec: bool = False
+
+def choose_mode(it: Item) -> str:
+    if it.pending_rec:
+        return "MC"
+    return "Text" if (it.streak >= 3.0 or it.mastery >= 0.50) else "MC"
+
+def record_correct(it: Item, mode: str, divisor: float):
+    weight = TEXT_WEIGHT if mode == "Text" else MC_WEIGHT
+    is_prod = (mode == "Text")
+    it.total += 1
+    it.correct += 1
+    it.streak += weight
+    if is_prod:
+        it.prod_in_streak += 1
+    eff = it.streak + 0.5 * it.prod_in_streak
+    streak_score = min(eff / divisor, 1.0)
+    boost = RECOVERY_BOOST if it.mastery > streak_score else 0.0
+    it.mastery = min(max(streak_score, it.mastery) + boost, 1.0)
+    it.sess_correct += 1
+    if mode == "MC":
+        it.sess_mc += 1
+    else:
+        it.sess_text += 1
+
+def ready_current(it: Item) -> tuple[bool, str]:
+    m, s = it.mastery, it.streak
+    if m >= 0.80 or s >= 8.0:
+        return (it.sess_text >= 1 and not it.pending_rec, "Tier1")
+    if m >= 0.50 or s >= 3.0:
+        return (it.sess_correct >= 2 and it.sess_text >= 1, "Tier2")
+    return (it.sess_mc >= 3 and it.sess_text >= 3, "Tier3")
+
+def ready_proposed(it: Item) -> tuple[bool, str]:
+    """Proposed rule:
+    Tier 1 (high): mastery>=0.80 OR streak>=8 → SessText>=1 AND !PendingRec  (UNCHANGED)
+    Tier 2 (mid):  mastery>=0.50 AND streak>=3 → SessCorrect>=4 AND SessText>=2
+    Tier 3 (low):  else → SessMC>=3 AND SessText>=3                           (UNCHANGED)
+
+    Key changes from current:
+      • Tier 2 trigger uses AND (not OR) — must have BOTH mid-mastery AND streak.
+      • Tier 2 floor raised from (2 corr, 1 text) → (4 corr, 2 text).
+    """
+    m, s = it.mastery, it.streak
+    if m >= 0.80 or s >= 8.0:
+        return (it.sess_text >= 1 and not it.pending_rec, "Tier1")
+    if m >= 0.50 and s >= 3.0:
+        return (it.sess_correct >= 4 and it.sess_text >= 2, "Tier2")
+    return (it.sess_mc >= 3 and it.sess_text >= 3, "Tier3")
+
+def walk(rule_name: str, divisor: float, ready_fn, max_turns=12, seed_mastery=0.0, seed_streak=0.0, seed_prod=0):
+    it = Item(mastery=seed_mastery, streak=seed_streak, prod_in_streak=seed_prod)
+    rows = []
+    rotated_at = None
+    for turn in range(1, max_turns + 1):
+        mode = choose_mode(it)
+        record_correct(it, mode, divisor)
+        ready, tier = ready_fn(it)
+        rows.append((turn, mode, it.streak, it.prod_in_streak, it.total, it.correct,
+                     it.sess_correct, it.sess_mc, it.sess_text, it.mastery, tier, ready))
+        if ready and rotated_at is None:
+            rotated_at = turn
+    return rows, rotated_at
+
+def fmt_table(title: str, rows):
+    print(f"\n### {title}")
+    print("| Turn | Mode | Streak | ProdInStreak | TotalAtt | CorrectAtt | SessCorrect | SessMC | SessText | Mastery | Tier  | ReadyToRotateOut |")
+    print("|------|------|--------|--------------|----------|------------|-------------|--------|----------|---------|-------|------------------|")
+    for (t, mode, st, pis, ta, ca, sc, smc, stx, m, tier, ready) in rows:
+        print(f"| {t}    | {mode:<4} | {st:>5.2f}  | {pis:>12} | {ta:>8} | {ca:>10} | {sc:>11} | {smc:>6} | {stx:>8} | {m:>5.3f}   | {tier} | {'**YES**' if ready else 'no':<16} |")
+
+def run_scenario(label: str, **seed):
+    print(f"\n## Scenario: {label}")
+    print(f"_Seed: mastery={seed.get('seed_mastery',0.0)}, streak={seed.get('seed_streak',0.0)}, prod_in_streak={seed.get('seed_prod',0)}_")
+    cur_rows, cur_at = walk("CURRENT", CURRENT_DIVISOR, ready_current, **seed)
+    new_rows, new_at = walk("PROPOSED", PROPOSED_DIVISOR, ready_proposed, **seed)
+    fmt_table("CURRENT (divisor=7.0, Tier 2 = streak≥3 OR m≥0.5 + SessC≥2 + ST≥1)", cur_rows)
+    print(f"\n→ **First rotation: turn {cur_at}**\n")
+    fmt_table("PROPOSED (divisor=12.0, Tier 2 = streak≥3 AND m≥0.5 + SessC≥4 + ST≥2)", new_rows)
+    print(f"\n→ **First rotation: turn {new_at}**")
+
+if __name__ == "__main__":
+    print("# Vocab Quiz Rotation Simulation")
+    run_scenario("Fresh word, all-correct, 12 turns")
+    run_scenario("Half-mastered word entering session (mastery=0.50, streak=3, prod=1), all-correct",
+                 seed_mastery=0.50, seed_streak=3.0, seed_prod=1)
+    run_scenario("Already-known word entering session (mastery=0.85, streak=6, prod=2), all-correct",
+                 seed_mastery=0.85, seed_streak=6.0, seed_prod=2)


### PR DESCRIPTION
Closes #191.

## Summary

Fresh words were rotating out of vocab quiz rounds at **turn 4** with all-correct answers — too fast for practice intent. This PR pushes the earliest legal rotation for a fresh word to **turn 5** without regressing already-known words. Two knobs are tuned.

## Production changes (2 lines)

| File | Change |
|------|--------|
| `VocabularyProgressService.cs:21` | `EFFECTIVE_STREAK_DIVISOR` `7.0f` → `12.0f` |
| `VocabularyQuizItem.cs:33-55` | Tier 2 trigger `OR` → `AND`, floor `(2,1)` → `(4,2)` |

**Why two knobs.** The divisor change alone slows mastery growth but Tier 2's `OR` trigger plus weak floor still let a fresh word slip out via a single Text correct + streak alone. The Tier 2 tightening closes that escape hatch.

## Simulator (fresh word, all-correct turns)

`tools/quiz-rotation-sim/sim.py` reproduces production math exactly. Run: `python3 tools/quiz-rotation-sim/sim.py`.

| Turn | Current (÷7, OR/2,1) | This PR (÷12, AND/4,2) |
|------|----------------------|------------------------|
| 4    | mastery 0.714 → **ROTATES** (bug) | mastery 0.417, no rotate |
| 5    | mastery 1.000        | mastery 0.583 → **ROTATES** |
| 6    | —                    | mastery 0.667 |

**Already-known words unchanged.** Mastery ≥ 0.80 + streak ≥ 8 still hits Tier 1 with a single text correct (Tier 1 logic unchanged). No spaced-repetition penalty for words already mastered.

**No user-data regression.** Stored `MasteryScore` cannot decrease from the divisor change because mastery is monotonic on correct: `max(streakScore, mastery)` at `VocabularyProgressService.cs:154`. Only words mid-climb grow more slowly going forward — which is the intent.

## Test impact

- **Jayne's repro** (`Repro191_NewWord_AllCorrect_DoesNotRotateOutBeforeFifthTurn`, from PR #195): **FAIL → PASS** ✅. This PR is branched off `test/vocab-quiz-scoring-repro-189-191` so the fix lands together with its verification harness.
- ~10 mastery-math fixtures updated to track the new divisor (5 MC + 2 Text → 8 MC + 2 Text demonstrations of `IsKnown`; divisor literals `/7.0f` → `/12.0f`).
- New test: `Tier2_TriggerRequiresBothMasteryAndStreak` covers the OR → AND change.
- Renamed: `Tier2_MidMastery_Rotates_2CorrectWith1Text` → `Tier2_MidMastery_Rotates_4CorrectWith2Text`, plus `Tier2_MidMastery_BlockedByLowSessionCorrect` for the new floor.
- **All 520 unit tests pass.**

## Captain & SLA review

Captain approved the two-knob proposal (full markdown lives in `.squad/decisions/inbox/wash-vocab-quiz-scoring-proposal-191.md`, gitignored). Language-tutor SLA review chose the turn-5 floor over a more aggressive turn-6 floor as the right balance between within-session retention demonstration and learner spaced-repetition load.

## Out of scope (separate issue)

- Decouple `MasteryScore` from `SessionRotationReady` so session pacing and long-term mastery tracking become independent levers — the higher-leverage architectural fix the tutor flagged. Tracked in #197 — out of scope for this PR.
- Wrong-answer mastery decay path is untouched (only the correct-answer divisor changes).
- No schema changes; obsolete-field write paths in `ProgressService` are not touched (sync compat).

## Manual verification before merge

Recommend a Mac Catalyst smoke per `.claude/skills/e2e-testing/references/quiz-activities.md`: load a fresh word, answer correctly several turns in a row, confirm rotation timing matches the simulator (rotates at turn 5, not turn 4) and Learning Details panel reflects the slower mastery climb.

## CI note

Pre-existing Linux MAUI/wasm-tools workload install failure on `main` is unrelated; per Captain's standing order, `gh pr merge --admin` is authorized if all unit tests are green and only that workload step fails.

