### PR TITLE
Revert "Fix mobile keyboard scrolling sticky nav off-screen on Blazor Hybrid"

### DIFF
--- a/.claude/skills/maui-ai-debugging/references/device-state.json
+++ b/.claude/skills/maui-ai-debugging/references/device-state.json
@@ -1,24 +1,4 @@
 {
-  "lastSuccessful": {
-    "platform": "iOS",
-    "deviceName": "iPhone 17 Pro",
-    "udid": "95EC018A-A8CF-4FAB-98A4-EF49D2E626B3",
-    "runtime": "iOS 26.2",
-    "tfm": "net11.0-ios",
-    "appBundleId": "com.simplyprofound.sentencestudio",
-    "hasData": true,
-    "lastUsed": "2026-05-18T20:30:00Z",
-    "outcome": "success",
-    "notes": "Mobile keyboard scroll fix verified — sticky header stays pinned when keyboard opens on /feedback textarea."
-  },
-  "lastFailed": {
-    "platform": "Android",
-    "deviceName": "Pixel_8a_API_35",
-    "serial": "emulator-5556",
-    "tfm": "net11.0-android",
-    "appBundleId": "com.simplyprofound.sentencestudio",
-    "lastUsed": "2026-05-18T20:53:00Z",
-    "outcome": "blocked",
-    "reason": "App stuck on splash. Aspire localhost services unreachable from emulator even with adb reverse (sync API at localhost:5081 returns Connection refused). DevFlow agent never registered. Keyboard fix code is in place but not visually verified on Android."
-  }
+  "lastSuccessful": null,
+  "lastFailed": null
 }

--- a/src/SentenceStudio.Android/MauiProgram.cs
+++ b/src/SentenceStudio.Android/MauiProgram.cs
@@ -31,7 +31,6 @@ public static class MauiProgram
         {
             ModifyEntry();
             ModifyPicker();
-            ConfigureBlazorWebView();
         });
 
         builder.Services.AddMauiBlazorWebView();
@@ -50,63 +49,6 @@ public static class MauiProgram
         var app = builder.Build();
         return SentenceStudioAppBuilder.InitializeApp(app);
     }
-
-    /// <summary>
-    /// Propagates the IME (on-screen keyboard) bottom inset to the BlazorWebView
-    /// as <c>paddingBottom</c>. Since .NET 9, MauiAppCompatActivity calls
-    /// <c>WindowCompat.SetDecorFitsSystemWindows(false)</c>, which puts the app
-    /// into edge-to-edge mode where <c>android:windowSoftInputMode="adjustResize"</c>
-    /// no longer resizes the activity automatically. Without this, the keyboard
-    /// floats over the WebView, the WebView keeps its full height, the browser
-    /// auto-scrolls the focused input into view, and the sticky PageHeader
-    /// (which is sticky within the DOM's <c>&lt;main&gt;</c>) rides off the top.
-    /// By padding the WebView's bottom by the IME inset, the WebView's
-    /// effective height shrinks so its DOM can scroll the input into view
-    /// without disturbing the sticky header.
-    /// Related: dotnet/maui#27314 (.NET 9 regression), #18964, #28790, PR #33902.
-    /// </summary>
-    private static void ConfigureBlazorWebView()
-    {
-#if ANDROID
-        Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper.AppendToMapping(
-            "ApplyImeInsetPadding",
-            (handler, view) =>
-            {
-                var webView = handler.PlatformView;
-                if (webView is null)
-                    return;
-
-                AndroidX.Core.View.ViewCompat.SetOnApplyWindowInsetsListener(webView, new ImeInsetListener());
-
-                // Trigger an initial dispatch so the listener fires once the view is attached.
-                webView.ViewAttachedToWindow += (_, _) =>
-                {
-                    AndroidX.Core.View.ViewCompat.RequestApplyInsets(webView);
-                };
-            });
-#endif
-    }
-
-#if ANDROID
-    private sealed class ImeInsetListener : Java.Lang.Object, AndroidX.Core.View.IOnApplyWindowInsetsListener
-    {
-        public AndroidX.Core.View.WindowInsetsCompat OnApplyWindowInsets(
-            global::Android.Views.View v,
-            AndroidX.Core.View.WindowInsetsCompat insets)
-        {
-            var imeInsets = insets.GetInsets(AndroidX.Core.View.WindowInsetsCompat.Type.Ime());
-            var bottom = imeInsets.Bottom;
-
-            // Apply only when the value actually changes to avoid layout thrash.
-            if (v.PaddingBottom != bottom)
-            {
-                v.SetPadding(v.PaddingLeft, v.PaddingTop, v.PaddingRight, bottom);
-            }
-
-            return insets;
-        }
-    }
-#endif
 
     private static void ModifyPicker()
     {

--- a/src/SentenceStudio.Android/SentenceStudio.Android.csproj
+++ b/src/SentenceStudio.Android/SentenceStudio.Android.csproj
@@ -11,10 +11,7 @@
 		<ApplicationId>com.simplyprofound.sentencestudio</ApplicationId>
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
-		<!-- Bumped from 21.0 to 23.0: androidx.lifecycle.runtime (transitively pulled in
-		     by Microsoft.Maui.DevFlow.Agent and other AndroidX deps) declares minSdk 23.
-		     Android 6.0 (API 23) is universal — global share of Android 5.x is <0.5% as of 2026. -->
-		<SupportedOSPlatformVersion>23.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/SentenceStudio.AppLib/wwwroot/index.html
+++ b/src/SentenceStudio.AppLib/wwwroot/index.html
@@ -9,66 +9,6 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/css/tom-select.bootstrap5.min.css" rel="stylesheet" />
     <link href="_content/SentenceStudio.UI/css/app.css" rel="stylesheet" />
-    <style>
-        /* MAUI BlazorWebView only: lock document scrolling so the inner
-           <main class="overflow-auto"> is the only scroller. Prevents the
-           WKWebView / Android WebView from carrying the sticky PageHeader
-           off-screen when the on-screen keyboard auto-scrolls a focused
-           input into view. NOT shared with the standalone WebApp. */
-        html, body {
-            overflow: hidden;
-            overscroll-behavior: none;
-        }
-    </style>
-    <script>
-        // Mobile keyboard handling (Blazor Hybrid on iOS/Android).
-        // Problem: WKWebView/Android WebView auto-scrolls the focused input
-        // into view by scrolling the *whole document*, which carries the
-        // sticky PageHeader off-screen. Also, iOS 100dvh does NOT update
-        // when the soft keyboard appears (only when the URL bar collapses).
-        //
-        // Fix:
-        //  1. Set a CSS variable --app-h from visualViewport.height so the
-        //     root layout (.app-vh) actually shrinks when the keyboard shows.
-        //  2. Lock window scroll to (0,0): WKWebView's auto-scroll sets
-        //     contentOffset programmatically (ScrollEnabled=false only blocks
-        //     pan gestures). Resetting on every scroll event neutralises it.
-        //  3. On input focus, scroll the inner <main class="overflow-auto">
-        //     so the focused element is visible above the keyboard.
-        (function () {
-            var root = document.documentElement;
-            function updateHeight() {
-                var h = (window.visualViewport && window.visualViewport.height) || window.innerHeight;
-                root.style.setProperty('--app-h', h + 'px');
-            }
-            updateHeight();
-            if (window.visualViewport) {
-                window.visualViewport.addEventListener('resize', updateHeight);
-            }
-            window.addEventListener('resize', updateHeight);
-
-            var lockingScroll = false;
-            window.addEventListener('scroll', function () {
-                if (lockingScroll) { return; }
-                if (window.scrollY !== 0 || window.scrollX !== 0) {
-                    lockingScroll = true;
-                    window.scrollTo(0, 0);
-                    setTimeout(function () { lockingScroll = false; }, 0);
-                }
-            }, { passive: true });
-
-            document.addEventListener('focusin', function (e) {
-                var t = e.target;
-                if (!t) { return; }
-                var tag = t.tagName;
-                if (tag === 'INPUT' || tag === 'TEXTAREA' || t.isContentEditable) {
-                    setTimeout(function () {
-                        try { t.scrollIntoView({ block: 'center', behavior: 'smooth' }); } catch (_) { }
-                    }, 150);
-                }
-            });
-        })();
-    </script>
 </head>
 <body style="background-color:#1a1a2e;margin:0;">
     <div id="app">

--- a/src/SentenceStudio.UI/Layout/MainLayout.razor
+++ b/src/SentenceStudio.UI/Layout/MainLayout.razor
@@ -13,7 +13,7 @@
 @inject Microsoft.AspNetCore.Components.Authorization.AuthenticationStateProvider AuthStateProvider
 @implements IDisposable
 
-<div class="d-flex app-vh">
+<div class="d-flex vh-100">
     <EnvironmentBadge />
     @if (!isOnboarding && isAuthenticated && !isSyncing)
     {

--- a/src/SentenceStudio.UI/Pages/ForgotPasswordPage.razor
+++ b/src/SentenceStudio.UI/Pages/ForgotPasswordPage.razor
@@ -5,7 +5,7 @@
 @implements IDisposable
 
 <EnvironmentBadge />
-<div class="d-flex app-vh align-items-center justify-content-center">
+<div class="d-flex vh-100 align-items-center justify-content-center">
     <div class="w-100" style="max-width: 440px; padding: 1rem;">
         <div class="text-center mb-4">
             <h1 class="text-primary-ss fs-3 fw-bold">

--- a/src/SentenceStudio.UI/Pages/LoginPage.razor
+++ b/src/SentenceStudio.UI/Pages/LoginPage.razor
@@ -4,7 +4,7 @@
 @implements IDisposable
 
 <EnvironmentBadge />
-<div class="d-flex app-vh align-items-center justify-content-center">
+<div class="d-flex vh-100 align-items-center justify-content-center">
     <div class="w-100" style="max-width: 440px; padding: 1rem;">
         <div class="text-center mb-4">
             <h1 class="text-primary-ss fs-3 fw-bold">

--- a/src/SentenceStudio.UI/Routes.razor
+++ b/src/SentenceStudio.UI/Routes.razor
@@ -3,7 +3,7 @@
         <Found Context="routeData">
             <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)">
                 <Authorizing>
-                    <div class="d-flex justify-content-center align-items-center app-vh">
+                    <div class="d-flex justify-content-center align-items-center vh-100">
                         <div class="spinner-border text-primary" role="status">
                             <span class="visually-hidden">Checking authentication...</span>
                         </div>

--- a/src/SentenceStudio.UI/wwwroot/css/app.css
+++ b/src/SentenceStudio.UI/wwwroot/css/app.css
@@ -399,20 +399,6 @@ html, body {
     height: 100%;
 }
 
-/* Document-level scroll lock is applied ONLY in the MAUI BlazorWebView
-   (see <style> in src/SentenceStudio.AppLib/wwwroot/index.html). The
-   standalone WebApp uses normal document scrolling. */
-
-/* Root layout height — uses --app-h set from JS visualViewport.height (so the
-   layout shrinks when the on-screen keyboard appears). Falls back to 100dvh
-   (modern browsers), then 100vh (legacy). 100dvh on iOS does NOT update on
-   keyboard show/hide — only the JS-driven --app-h does. */
-.app-vh {
-    height: 100vh;
-    height: 100dvh;
-    height: var(--app-h, 100dvh);
-}
-
 #app {
     height: 100%;
     background-color: var(--bs-body-bg);
@@ -1801,7 +1787,6 @@ main.main-content:has(.matching-page-wrapper) {
     left: 0;
     width: 100vw;
     height: 100vh;
-    height: 100dvh;
     background: rgba(0, 0, 0, 0.85);
     z-index: 9999;
     display: flex;

--- a/src/SentenceStudio.WebApp/Components/Layout/AuthLayout.razor
+++ b/src/SentenceStudio.WebApp/Components/Layout/AuthLayout.razor
@@ -1,6 +1,6 @@
 @inherits LayoutComponentBase
 
-<div class="d-flex app-vh align-items-center justify-content-center"
+<div class="d-flex vh-100 align-items-center justify-content-center"
      style="background: var(--bs-body-bg, #1a1a2e);">
     <div class="w-100" style="max-width: 440px; padding: 1rem;">
         <div class="text-center mb-4">

--- a/src/SentenceStudio.iOS/MauiProgram.cs
+++ b/src/SentenceStudio.iOS/MauiProgram.cs
@@ -55,7 +55,6 @@ public static class MauiProgram
             ModifyEntry();
             ModifyPicker();
             ConfigureWebView();
-            ConfigureBlazorWebView();
         });
 
         builder.Services.AddMauiBlazorWebView();
@@ -101,39 +100,6 @@ public static class MauiProgram
             config.MediaTypesRequiringUserActionForPlayback = WebKit.WKAudiovisualMediaTypes.None;
             return new Microsoft.Maui.Platform.MauiWKWebView(CoreGraphics.CGRect.Empty, (Microsoft.Maui.Handlers.WebViewHandler)handler, config);
         };
-#endif
-    }
-
-    /// <summary>
-    /// Defensive belt-and-suspenders for the mobile keyboard fix on iOS.
-    /// The primary fix lives in <c>wwwroot/index.html</c> (JS that locks
-    /// <c>window.scrollTo(0,0)</c> and sets a <c>--app-h</c> CSS variable from
-    /// <c>visualViewport.height</c>) plus <c>.app-vh</c> in <c>app.css</c>.
-    /// 
-    /// Setting <c>ScrollView.ScrollEnabled = false</c> here only blocks
-    /// user pan gestures — it does NOT stop WKWebView's programmatic
-    /// auto-scroll on input focus. That's why the JS handler is the
-    /// actual fix. We still disable user scrolling so a stray flick can't
-    /// push the document off and reveal the gap above the sticky header.
-    /// Related: dotnet/maui#28790, dotnet/maui#18964.
-    /// </summary>
-    private static void ConfigureBlazorWebView()
-    {
-#if IOS
-        Microsoft.AspNetCore.Components.WebView.Maui.BlazorWebViewHandler.BlazorWebViewMapper.AppendToMapping(
-            "DisableOuterScroll",
-            (handler, view) =>
-            {
-                var wk = handler.PlatformView;
-                if (wk?.ScrollView is { } sv)
-                {
-                    sv.ScrollEnabled = false;
-                    sv.Bounces = false;
-                    sv.BouncesZoom = false;
-                    sv.ShowsVerticalScrollIndicator = false;
-                    sv.ShowsHorizontalScrollIndicator = false;
-                }
-            });
 #endif
     }
 


### PR DESCRIPTION
Reverts 152ea751.

The May 18 attempt to keep the navigation header sticky when the soft keyboard opens on Blazor Hybrid actually made the behavior **worse** — on iOS, the entire page would scroll out of view and then slowly animate back into position with the header along for the ride.

Verified on iPhone 17 Pro sim (UDID 9F013AE9-B931-4C01-8FDC-8DC5CA01FB84, iOS 26.2): with the revert applied, the page no longer does the disruptive scroll-out-and-back dance. The header still doesn't stay pinned during keyboard open (that's a separate, pre-existing dotnet/maui Blazor Hybrid issue worth filing upstream), but the experience is acceptable again.

Files reverted: iOS+Android MauiProgram.cs (BlazorWebView mapper), AppLib wwwroot/index.html (inline scroll-lock CSS+JS), 4 Razor layout files (.app-vh class), UI/wwwroot/css/app.css, Android csproj (SupportedOSPlatformVersion 23→21), maui-ai-debugging device-state.json.