### PR TITLE
fix(diary): allow Diary AI feedback DTOs through gateway type registry

### DIFF
--- a/src/SentenceStudio.Api/AiResponseTypeRegistry.cs
+++ b/src/SentenceStudio.Api/AiResponseTypeRegistry.cs
@@ -22,6 +22,8 @@ internal static class AiResponseTypeRegistry
         {
             typeof(BulkTranslationResponse),
             typeof(ClozureResponse),
+            typeof(DiaryFeedbackResponse),
+            typeof(DiaryPromptResponse),
             typeof(FreeTextVocabularyExtractionResponse),
             typeof(GradeResponse),
             typeof(Reply),

--- a/src/SentenceStudio.AppLib/Services/DiaryService.cs
+++ b/src/SentenceStudio.AppLib/Services/DiaryService.cs
@@ -1,7 +1,7 @@
-using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 using Scriban;
 using SentenceStudio.Abstractions;
+using SentenceStudio.Shared.Models;
 
 namespace SentenceStudio.Services;
 
@@ -94,25 +94,4 @@ public class DiaryService
             return null;
         }
     }
-}
-
-public class DiaryPromptResponse
-{
-    [Description("A short, open-ended diary writing prompt in the learner's target language. One or two sentences, max ~20 target-language words.")]
-    public string Prompt { get; set; } = string.Empty;
-
-    [Description("A brief one-line hint in the learner's native language explaining what the prompt is asking, for lower-level learners.")]
-    public string Hint { get; set; } = string.Empty;
-}
-
-public class DiaryFeedbackResponse
-{
-    [Description("The learner's diary entry rewritten in clear, natural target-language prose. Preserves the learner's meaning and voice. Do not add content the learner did not express.")]
-    public string Recommended { get; set; } = string.Empty;
-
-    [Description("Grammar, vocabulary, and style observations written in the learner's native language. 2-4 short bullet-style sentences focused on the most useful corrections.")]
-    public string Notes { get; set; } = string.Empty;
-
-    [Description("1-2 short sentences in the learner's native language pointing out what the learner did well. Be specific and genuine.")]
-    public string Strengths { get; set; } = string.Empty;
 }

--- a/src/SentenceStudio.Shared/Models/DiaryAiResponses.cs
+++ b/src/SentenceStudio.Shared/Models/DiaryAiResponses.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel;
+
+namespace SentenceStudio.Shared.Models;
+
+/// <summary>
+/// AI response for the Diary daily writing prompt generator.
+/// Lives in <c>SentenceStudio.Shared.Models</c> so the API project can register it
+/// in <c>AiResponseTypeRegistry</c> for structured-output deserialization through
+/// the AI gateway.
+/// </summary>
+public class DiaryPromptResponse
+{
+    [Description("A short, open-ended diary writing prompt in the learner's target language. One or two sentences, max ~20 target-language words.")]
+    public string Prompt { get; set; } = string.Empty;
+
+    [Description("A brief one-line hint in the learner's native language explaining what the prompt is asking, for lower-level learners.")]
+    public string Hint { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// AI feedback response for a learner's diary entry: a recommended rewrite plus
+/// short notes and strengths in the learner's native language.
+/// </summary>
+public class DiaryFeedbackResponse
+{
+    [Description("The learner's diary entry rewritten in clear, natural target-language prose. Preserves the learner's meaning and voice. Do not add content the learner did not express.")]
+    public string Recommended { get; set; } = string.Empty;
+
+    [Description("Grammar, vocabulary, and style observations written in the learner's native language. 2-4 short bullet-style sentences focused on the most useful corrections.")]
+    public string Notes { get; set; } = string.Empty;
+
+    [Description("1-2 short sentences in the learner's native language pointing out what the learner did well. Be specific and genuine.")]
+    public string Strengths { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Problem
Diary AI feedback ("Get feedback" on a diary entry) was erroring out with a "feedback failed" toast.

## Root cause
`DiaryFeedbackResponse` and `DiaryPromptResponse` were defined in `SentenceStudio.AppLib.Services.DiaryService.cs`. The API project does NOT reference `AppLib`, so these types could not be added to the `AiResponseTypeRegistry.AllowedTypes` allow-list.

When the webapp called `/api/v1/ai/chat` with `ResponseType=SentenceStudio.Services.DiaryFeedbackResponse...`, the API's `ResolveResponseType` returned null, and the gateway silently fell back to a plain-text response. `AiGatewayClient.DeserializeResponse<T>` then threw `JsonException`, which was swallowed and surfaced as the user-facing toast.

## Fix
- Moved `DiaryPromptResponse` and `DiaryFeedbackResponse` to `src/SentenceStudio.Shared/Models/DiaryAiResponses.cs` (namespace `SentenceStudio.Shared.Models`) — same pattern as the other 13 AI response DTOs the API references via `typeof`.
- Updated `DiaryService.cs` to import `SentenceStudio.Shared.Models`.
- Registered `typeof(DiaryFeedbackResponse)` and `typeof(DiaryPromptResponse)` in `AiResponseTypeRegistry.AllowedTypes`.

## Verified
- API build: 0 errors.
- E2E on local Aspire (Mac Catalyst webapp + API): wrote a Korean diary entry → clicked "Get feedback" → all three sections rendered (Recommended rewrite, Notes, Strengths) with high-quality output.
- Aspire structured logs: zero `Failed to deserialize AI gateway response` warnings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>