### PR TITLE
Fix Brot vocabulary leak: reachability filter + cascade orphan sweep

### DIFF
--- a/src/SentenceStudio.Shared/Data/LearningResourceRepository.cs
+++ b/src/SentenceStudio.Shared/Data/LearningResourceRepository.cs
@@ -328,18 +328,64 @@ public class LearningResourceRepository
         using var scope = _serviceProvider.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
+        using var tx = await db.Database.BeginTransactionAsync();
         try
         {
-            db.LearningResources.Remove(resource);
-            int result = await db.SaveChangesAsync();
+            // Capture the vocab IDs reachable via this resource BEFORE removing the resource;
+            // ResourceVocabularyMapping cascades to gone, so we can't read them after the fact.
+            var resourceWordIds = await db.ResourceVocabularyMappings
+                .Where(m => m.ResourceId == resource.Id)
+                .Select(m => m.VocabularyWordId)
+                .Distinct()
+                .ToListAsync();
 
+            db.LearningResources.Remove(resource);
+            int affected = await db.SaveChangesAsync();
+
+            // Cascade orphan sweep: for each vocab word this resource owned a mapping for,
+            // check whether the SAME user can still reach the word via another of their
+            // resources. If not, delete the user's VocabularyProgress row so it doesn't become
+            // an "eternally due" orphan that pollutes plan generation. Matches the user's
+            // mental model — "if I removed the resource, my progress on its words is gone too".
+            // See Brot incident, 2026-06-12.
+            var ownerUserId = resource.UserProfileId;
+            if (resourceWordIds.Count > 0 && !string.IsNullOrEmpty(ownerUserId))
+            {
+                var stillReachableWordIds = await db.ResourceVocabularyMappings
+                    .Where(m => resourceWordIds.Contains(m.VocabularyWordId))
+                    .Join(db.LearningResources.Where(r => r.UserProfileId == ownerUserId),
+                          m => m.ResourceId,
+                          r => r.Id,
+                          (m, r) => m.VocabularyWordId)
+                    .Distinct()
+                    .ToListAsync();
+                var orphanedWordIds = resourceWordIds.Except(stillReachableWordIds).ToList();
+                if (orphanedWordIds.Count > 0)
+                {
+                    var orphanProgress = await db.VocabularyProgresses
+                        .Where(vp => vp.UserId == ownerUserId
+                            && orphanedWordIds.Contains(vp.VocabularyWordId))
+                        .ToListAsync();
+                    if (orphanProgress.Count > 0)
+                    {
+                        db.VocabularyProgresses.RemoveRange(orphanProgress);
+                        await db.SaveChangesAsync();
+                        _logger.LogInformation(
+                            "DeleteResourceAsync orphan sweep: removed {Count} VocabularyProgress rows for user {UserId} that lost their last reachable mapping after deleting resource {ResourceId}",
+                            orphanProgress.Count, ownerUserId, resource.Id);
+                    }
+                }
+            }
+
+            await tx.CommitAsync();
             _syncService?.TriggerSyncAsync().ConfigureAwait(false);
 
-            return result;
+            return affected;
         }
         catch (Exception ex)
         {
-            // UXDivers popup removed - error already logged above
+            _logger.LogError(ex, "❌ DeleteResourceAsync error for resource {ResourceId}", resource.Id);
+            try { await tx.RollbackAsync(); } catch { }
             return -1;
         }
     }

--- a/src/SentenceStudio.Shared/Data/VocabularyProgressRepository.cs
+++ b/src/SentenceStudio.Shared/Data/VocabularyProgressRepository.cs
@@ -225,6 +225,11 @@ public class VocabularyProgressRepository
     public async Task<(int New, int Learning, int Familiar, int Review, int Known)> GetVocabSummaryCountsAsync(string userId = "")
     {
         if (string.IsNullOrEmpty(userId)) userId = !string.IsNullOrEmpty(ActiveUserId) ? ActiveUserId : string.Empty;
+        if (string.IsNullOrEmpty(userId))
+        {
+            _logger.LogWarning("GetVocabSummaryCountsAsync called with no active userId — returning empty counts");
+            return (0, 0, 0, 0, 0);
+        }
         using var scope = _serviceProvider.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
@@ -239,8 +244,16 @@ public class VocabularyProgressRepository
             .CountAsync();
 
         // PHASE 2: Load progress records for words that have been practiced
+        // Apply reachability filter: only count progress for words still mapped to one of
+        // this user's resources. Without this, orphan VocabularyProgress rows (e.g. left
+        // over from a deleted resource) inflate Learning/Review/Known counts and skew
+        // wordsNeverSeen math. See Brot incident, 2026-06-12.
         var allProgress = await db.VocabularyProgresses
-            .Where(vp => vp.UserId == userId)
+            .Where(vp => vp.UserId == userId
+                && db.Set<ResourceVocabularyMapping>().Any(rvm =>
+                    rvm.VocabularyWordId == vp.VocabularyWordId
+                    && db.Set<LearningResource>().Any(lr =>
+                        lr.Id == rvm.ResourceId && lr.UserProfileId == userId)))
             .Select(vp => new
             {
                 vp.TotalAttempts,
@@ -306,17 +319,29 @@ public class VocabularyProgressRepository
     /// <summary>
     /// Get count of vocabulary words due for review based on SRS schedule.
     /// Excludes words that are already Known (MasteryScore >= 0.85 AND ProductionInStreak >= 2).
+    /// REACHABILITY-SCOPED: only counts words reachable via a ResourceVocabularyMapping to a
+    /// LearningResource owned by the same user. Without this filter, orphan progress rows
+    /// (e.g. left behind when a resource was removed in the past) count as "due forever"
+    /// and pollute plan generation. See Brot incident, 2026-06-12.
     /// </summary>
     public async Task<int> GetDueVocabCountAsync(DateTime asOfDate, string userId = "")
     {
         if (string.IsNullOrEmpty(userId)) userId = !string.IsNullOrEmpty(ActiveUserId) ? ActiveUserId : string.Empty;
+        if (string.IsNullOrEmpty(userId))
+        {
+            _logger.LogWarning("GetDueVocabCountAsync called without an active user — returning 0 to prevent cross-tenant data leak.");
+            return 0;
+        }
         using var scope = _serviceProvider.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
         var dueCount = await db.VocabularyProgresses
             .Where(vp => vp.UserId == userId
                 && vp.NextReviewDate <= asOfDate
-                && !(vp.MasteryScore >= 0.85f && vp.ProductionInStreak >= 2))
+                && !(vp.MasteryScore >= 0.85f && vp.ProductionInStreak >= 2)
+                && db.ResourceVocabularyMappings.Any(m =>
+                    m.VocabularyWordId == vp.VocabularyWordId
+                    && db.LearningResources.Any(r => r.Id == m.ResourceId && r.UserProfileId == userId)))
             .CountAsync();
 
         return dueCount;
@@ -326,10 +351,19 @@ public class VocabularyProgressRepository
     /// Get vocabulary words due for review with word and resource details for planning.
     /// Excludes words that are already Known (MasteryScore >= 0.85 AND ProductionInStreak >= 2)
     /// so that the Today Plan focuses on words that still need active learning.
+    /// REACHABILITY-SCOPED: only returns words reachable via a ResourceVocabularyMapping to a
+    /// LearningResource owned by the same user. Symmetric with GetUnseenMappedVocabularyAsync
+    /// below. Without this filter, orphan progress rows (e.g. words from a resource the user
+    /// removed in the past) get picked into "due review" lists. See Brot incident, 2026-06-12.
     /// </summary>
     public async Task<List<VocabularyProgress>> GetDueVocabularyAsync(DateTime asOfDate, string userId = "")
     {
         if (string.IsNullOrEmpty(userId)) userId = !string.IsNullOrEmpty(ActiveUserId) ? ActiveUserId : string.Empty;
+        if (string.IsNullOrEmpty(userId))
+        {
+            _logger.LogWarning("GetDueVocabularyAsync called without an active user — returning empty result to prevent cross-tenant data leak.");
+            return new List<VocabularyProgress>();
+        }
         using var scope = _serviceProvider.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
@@ -339,7 +373,10 @@ public class VocabularyProgressRepository
                 .ThenInclude(lc => lc.LearningResource)
             .Where(vp => vp.UserId == userId
                 && vp.NextReviewDate <= asOfDate
-                && !(vp.MasteryScore >= 0.85f && vp.ProductionInStreak >= 2))
+                && !(vp.MasteryScore >= 0.85f && vp.ProductionInStreak >= 2)
+                && db.ResourceVocabularyMappings.Any(m =>
+                    m.VocabularyWordId == vp.VocabularyWordId
+                    && db.LearningResources.Any(r => r.Id == m.ResourceId && r.UserProfileId == userId)))
             .ToListAsync();
 
         return dueWords;

--- a/src/SentenceStudio.Shared/Services/Progress/ProgressCacheService.cs
+++ b/src/SentenceStudio.Shared/Services/Progress/ProgressCacheService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using SentenceStudio.Abstractions;
 
@@ -6,6 +7,9 @@ namespace SentenceStudio.Services.Progress;
 /// <summary>
 /// PHASE 2 OPTIMIZATION: Simple in-memory cache for progress data.
 /// All entries are keyed by userId to prevent cross-profile data bleed.
+/// Backed by <see cref="ConcurrentDictionary{TKey, TValue}"/> because this service is
+/// registered as a Singleton and read/written from many concurrent Blazor circuits + sync
+/// callbacks. Plain Dictionary was a latent race (see Brot incident, 2026-06-12).
 /// </summary>
 public class ProgressCacheService
 {
@@ -20,11 +24,11 @@ public class ProgressCacheService
     }
 
     // Cache entries keyed by userId
-    private readonly Dictionary<string, CacheEntry<VocabProgressSummary>> _vocabSummaryCache = new();
-    private readonly Dictionary<string, CacheEntry<IReadOnlyList<PracticeHeatPoint>>> _practiceHeatCache = new();
-    private readonly Dictionary<string, CacheEntry<List<ResourceProgress>>> _resourceProgressCache = new();
-    private readonly Dictionary<string, CacheEntry<SkillProgress>> _skillProgressCache = new();
-    private readonly Dictionary<string, CacheEntry<TodaysPlan>> _todaysPlanCache = new();
+    private readonly ConcurrentDictionary<string, CacheEntry<VocabProgressSummary>> _vocabSummaryCache = new();
+    private readonly ConcurrentDictionary<string, CacheEntry<IReadOnlyList<PracticeHeatPoint>>> _practiceHeatCache = new();
+    private readonly ConcurrentDictionary<string, CacheEntry<List<ResourceProgress>>> _resourceProgressCache = new();
+    private readonly ConcurrentDictionary<string, CacheEntry<SkillProgress>> _skillProgressCache = new();
+    private readonly ConcurrentDictionary<string, CacheEntry<TodaysPlan>> _todaysPlanCache = new();
 
     private string UserId => _preferences.Get("active_profile_id", string.Empty);
 
@@ -107,22 +111,22 @@ public class ProgressCacheService
 
     public void InvalidateVocabSummary()
     {
-        _vocabSummaryCache.Remove(UserId);
+        _vocabSummaryCache.TryRemove(UserId, out _);
     }
 
     public void InvalidatePracticeHeat()
     {
-        _practiceHeatCache.Remove(UserId);
+        _practiceHeatCache.TryRemove(UserId, out _);
     }
 
     public void InvalidateResourceProgress()
     {
-        _resourceProgressCache.Remove(UserId);
+        _resourceProgressCache.TryRemove(UserId, out _);
     }
 
     public void InvalidateSkillProgress(string skillId)
     {
-        _skillProgressCache.Remove($"{UserId}:{skillId}");
+        _skillProgressCache.TryRemove($"{UserId}:{skillId}", out _);
     }
 
     // Plan cache methods take an explicit date parameter to avoid timezone drift.
@@ -153,7 +157,7 @@ public class ProgressCacheService
     public void InvalidateTodaysPlan(DateTime date)
     {
         var key = BuildPlanKey(date);
-        _todaysPlanCache.Remove(key);
+        _todaysPlanCache.TryRemove(key, out _);
     }
 
     public void UpdateTodaysPlan(DateTime date, TodaysPlan data)

--- a/src/SentenceStudio.Shared/Services/Progress/ProgressService.cs
+++ b/src/SentenceStudio.Shared/Services/Progress/ProgressService.cs
@@ -235,8 +235,38 @@ public class ProgressService : IProgressService
         if (existingPlan != null)
             return existingPlan;
 
-        _logger.LogDebug("🤖 Generating new plan with LLM...");
+        // Single-flight per user — without this gate, two concurrent cache-misses
+        // (e.g. Blazor circuit reconnect + a parallel mobile sync) both call the LLM and both
+        // write DailyPlanCompletion rows with different content-hashed PlanItemIds. The first
+        // pass's rows then leak stale NarrativeJson into the dashboard via
+        // ReconstructPlanFromDatabase. See Brot incident, 2026-06-12. Keyed on userId only
+        // (not user×date) to keep the gate dictionary bounded by user count rather than
+        // unbounded growth over time. Inside the gate we always check the cache for today.
+        var profile = await _userProfileRepo.GetAsync();
+        var lockKey = profile?.Id ?? "unknown";
+        var gate = _planGenGates.GetOrAdd(lockKey, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct);
+        try
+        {
+            // Double-check after acquiring the gate: another caller may have just produced it.
+            existingPlan = await GetCachedPlanAsync(today, ct);
+            if (existingPlan != null)
+                return existingPlan;
 
+            _logger.LogDebug("🤖 Generating new plan with LLM...");
+
+            return await GenerateTodaysPlanCoreAsync(today, ct);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, SemaphoreSlim> _planGenGates = new();
+
+    private async Task<TodaysPlan> GenerateTodaysPlanCoreAsync(DateTime today, CancellationToken ct)
+    {
         try
         {
             // Use LLM to generate the plan
@@ -292,7 +322,7 @@ public class ProgressService : IProgressService
                 vocabDueCount,
                 llmResponse.Narrative
             );
-            
+
             // NumberDrill telemetry (Phase 2)
             var numberDrillItem = plan.Items.FirstOrDefault(i => i.ActivityType == PlanActivityType.NumberDrill);
             if (numberDrillItem != null)
@@ -1251,15 +1281,15 @@ public class ProgressService : IProgressService
             var existing = await db.DailyPlanCompletions
                 .FirstOrDefaultAsync(c => c.Date == plan.GeneratedForDate.Date && c.PlanItemId == item.Id && c.UserProfileId == userProfile.Id, ct);
 
+            // Serialize narrative to JSON once per loop
+            string? narrativeJson = null;
+            if (plan.Narrative != null)
+            {
+                narrativeJson = System.Text.Json.JsonSerializer.Serialize(plan.Narrative);
+            }
+
             if (existing == null)
             {
-                // Serialize narrative to JSON
-                string? narrativeJson = null;
-                if (plan.Narrative != null)
-                {
-                    narrativeJson = System.Text.Json.JsonSerializer.Serialize(plan.Narrative);
-                }
-
                 var completion = new DailyPlanCompletion
                 {
                     Id = Guid.NewGuid().ToString(),
@@ -1285,8 +1315,45 @@ public class ProgressService : IProgressService
             }
             else
             {
-                _logger.LogDebug("  ⏭️ Record already exists for {TitleKey} ({MinutesSpent} min)", item.TitleKey, existing.MinutesSpent);
+                // REFRESH (don't skip): the plan re-generation must update the descriptive
+                // fields (narrative/rationale/labels/priority) so the dashboard preview never
+                // diverges from the activities. PRESERVE user-progress fields
+                // (MinutesSpent/IsCompleted/CompletedAt) so we don't destroy work.
+                // See Brot incident, 2026-06-12 — INSERT-only behaviour kept a stale narrative
+                // from an earlier pass alive after the canonical pass replaced it.
+                existing.ActivityType = item.ActivityType.ToString();
+                existing.ResourceId = item.ResourceId;
+                existing.SkillId = item.SkillId;
+                existing.EstimatedMinutes = item.EstimatedMinutes;
+                existing.Priority = item.Priority;
+                existing.TitleKey = item.TitleKey;
+                existing.DescriptionKey = item.DescriptionKey;
+                existing.Rationale = plan.Rationale ?? existing.Rationale;
+                existing.NarrativeJson = narrativeJson ?? existing.NarrativeJson;
+                existing.UpdatedAt = DateTime.UtcNow;
+                _logger.LogDebug("  ♻️ Refreshed record for {TitleKey} ({MinutesSpent} min preserved)", item.TitleKey, existing.MinutesSpent);
             }
+        }
+
+        // Orphan cleanup: remove completion rows for PlanItemIds no longer in today's plan,
+        // BUT only when they have zero user progress (MinutesSpent=0 AND !IsCompleted).
+        // This eliminates leftover rows from a prior plan-gen pass without ever destroying
+        // user work. Adhoc rows (PlanItemId starts with "adhoc-") are out of scope — those
+        // are manual additions and should never be auto-removed.
+        var currentPlanItemIds = plan.Items.Select(i => i.Id).ToHashSet(StringComparer.Ordinal);
+        var staleRows = await db.DailyPlanCompletions
+            .Where(c => c.Date == plan.GeneratedForDate.Date
+                && c.UserProfileId == userProfile.Id
+                && !c.PlanItemId.StartsWith("adhoc-")
+                && !currentPlanItemIds.Contains(c.PlanItemId)
+                && c.MinutesSpent == 0
+                && !c.IsCompleted)
+            .ToListAsync(ct);
+        if (staleRows.Count > 0)
+        {
+            db.DailyPlanCompletions.RemoveRange(staleRows);
+            _logger.LogInformation("🧹 Removed {Count} stale DailyPlanCompletion rows from a previous plan-gen pass (PlanItemIds: {Ids})",
+                staleRows.Count, string.Join(",", staleRows.Select(r => r.PlanItemId)));
         }
 
         await db.SaveChangesAsync(ct);
@@ -1334,17 +1401,29 @@ public class ProgressService : IProgressService
             .FirstOrDefaultAsync(ct);
         var planFocusVocabularyIds = DeserializeFocusVocabularyFacts(planFocusVocabularyFacts);
 
-        // Extract rationale from first record (stored redundantly in all records for same date)
-        var rationale = completions.FirstOrDefault()?.Rationale ?? string.Empty;
+        // Pick the FRESHEST surviving completion as the narrative/rationale source.
+        // InitializePlanCompletionRecordsAsync now refreshes existing rows + deletes orphaned
+        // PlanItemIds from prior plan-gen passes, so all surviving rows should already carry
+        // the same narrative. This UpdatedAt-DESC ordering is belt-and-suspenders: if a row
+        // survives orphan cleanup (e.g. it has user-progress on it), its narrative will be
+        // the most recently refreshed, never the stale one from a previous pass.
+        // See Brot incident, 2026-06-12.
+        var freshest = completions
+            .OrderByDescending(c => c.UpdatedAt)
+            .ThenByDescending(c => c.CreatedAt)
+            .FirstOrDefault();
 
-        // Deserialize narrative from first record (stored redundantly)
+        // Extract rationale from freshest record (stored redundantly in all records for same date)
+        var rationale = freshest?.Rationale ?? string.Empty;
+
+        // Deserialize narrative from freshest record (stored redundantly)
         PlanNarrative? narrative = null;
-        var firstNarrativeJson = completions.FirstOrDefault()?.NarrativeJson;
-        if (!string.IsNullOrEmpty(firstNarrativeJson))
+        var freshestNarrativeJson = freshest?.NarrativeJson;
+        if (!string.IsNullOrEmpty(freshestNarrativeJson))
         {
             try
             {
-                narrative = System.Text.Json.JsonSerializer.Deserialize<PlanNarrative>(firstNarrativeJson);
+                narrative = System.Text.Json.JsonSerializer.Deserialize<PlanNarrative>(freshestNarrativeJson);
             }
             catch (Exception ex)
             {

--- a/tests/SentenceStudio.UnitTests/Services/BrotOrphanProgressRegressionTests.cs
+++ b/tests/SentenceStudio.UnitTests/Services/BrotOrphanProgressRegressionTests.cs
@@ -1,0 +1,370 @@
+// REGRESSION TESTS — orphaned VocabularyProgress rows must not pollute plan generation
+// or be revivable through any read path. These tests exist because of the "Brot incident"
+// on 2026-06-12: a German word from a long-removed LearningResource appeared in Captain's
+// production Today Plan / Flashcard Preview, despite his account being Korean-only.
+//
+// Root cause (two cooperating bugs):
+//   1. GetDueVocabularyAsync filtered by UserId + NextReviewDate only — no reachability
+//      JOIN to ResourceVocabularyMapping → LearningResource(UserProfileId=user). When a
+//      user removed a LearningResource months earlier, the FK cascade dropped the
+//      mappings but NOT the VocabularyProgress rows. Those orphans sat at
+//      NextReviewDate=2026-02-12 with MasteryScore=0.143 — "eternally overdue".
+//   2. LearningResourceRepository.DeleteResourceAsync did not sweep orphan progress at
+//      delete time, so future plan-generation would re-pick those words forever.
+//
+// If these tests fail, the Brot bug is back. DO NOT DELETE OR WEAKEN.
+
+using Xunit;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SentenceStudio.Abstractions;
+using SentenceStudio.Data;
+using SentenceStudio.Shared.Models;
+
+namespace SentenceStudio.UnitTests.Services;
+
+public class BrotOrphanProgressRegressionTests : IDisposable
+{
+    private const string Captain = "captain-id";
+    private const string OtherUser = "other-user-id";
+
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _serviceProvider;
+    private readonly VocabularyProgressRepository _progressRepo;
+    private readonly LearningResourceRepository _resourceRepo;
+
+    public BrotOrphanProgressRegressionTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var mockPrefs = new Mock<IPreferencesService>();
+        mockPrefs.Setup(p => p.Get("active_profile_id", string.Empty)).Returns(Captain);
+
+        var mockFs = new Mock<IFileSystemService>();
+        mockFs.Setup(f => f.AppDataDirectory).Returns(Path.GetTempPath());
+
+        var services = new ServiceCollection();
+        services.AddDbContext<ApplicationDbContext>(opts => opts.UseSqlite(_connection));
+        services.AddSingleton<IPreferencesService>(mockPrefs.Object);
+        services.AddSingleton<IFileSystemService>(mockFs.Object);
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            db.Database.EnsureCreated();
+        }
+
+        _progressRepo = new VocabularyProgressRepository(
+            _serviceProvider,
+            NullLogger<VocabularyProgressRepository>.Instance);
+
+        _resourceRepo = new LearningResourceRepository(
+            _serviceProvider,
+            NullLogger<LearningResourceRepository>.Instance,
+            mockFs.Object);
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider.Dispose();
+        _connection.Dispose();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Test helpers
+    // ──────────────────────────────────────────────────────────────────
+
+    /// <summary>Seed a word, a resource for the user, and a mapping that connects them.</summary>
+    private void SeedReachableWord(string userId, string wordId, string resourceId, string language = "Korean")
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.VocabularyWords.Add(new VocabularyWord
+        {
+            Id = wordId,
+            TargetLanguageTerm = $"term-{wordId}",
+            NativeLanguageTerm = $"meaning-{wordId}",
+            Language = language
+        });
+        db.LearningResources.Add(new LearningResource
+        {
+            Id = resourceId,
+            UserProfileId = userId,
+            Title = $"Resource {resourceId}",
+            Language = language,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        db.ResourceVocabularyMappings.Add(new ResourceVocabularyMapping
+        {
+            Id = Guid.NewGuid().ToString(),
+            ResourceId = resourceId,
+            VocabularyWordId = wordId
+        });
+        db.SaveChanges();
+    }
+
+    /// <summary>Seed a word with NO mapping to any of the user's resources (orphan scenario).</summary>
+    private void SeedOrphanWord(string wordId, string language = "German")
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.VocabularyWords.Add(new VocabularyWord
+        {
+            Id = wordId,
+            TargetLanguageTerm = $"term-{wordId}",
+            NativeLanguageTerm = $"meaning-{wordId}",
+            Language = language
+        });
+        db.SaveChanges();
+    }
+
+    private void SeedProgress(string userId, string wordId, DateTime? nextReviewDate = null, float mastery = 0.143f)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.VocabularyProgresses.Add(new VocabularyProgress
+        {
+            Id = Guid.NewGuid().ToString(),
+            VocabularyWordId = wordId,
+            UserId = userId,
+            TotalAttempts = 1,
+            CorrectAttempts = 0,
+            MasteryScore = mastery,
+            ProductionInStreak = 0,
+            NextReviewDate = nextReviewDate ?? DateTime.UtcNow.AddDays(-100), // long overdue
+            FirstSeenAt = DateTime.UtcNow.AddDays(-100),
+            LastPracticedAt = DateTime.UtcNow.AddDays(-100),
+            CreatedAt = DateTime.UtcNow.AddDays(-100),
+            UpdatedAt = DateTime.UtcNow.AddDays(-100)
+        });
+        db.SaveChanges();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // GetDueVocabularyAsync reachability filter
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetDueVocabularyAsync_ExcludesOrphanProgressWithNoUserMapping()
+    {
+        // Captain has 1 reachable Korean word and 1 orphaned German word ("Brot").
+        SeedReachableWord(Captain, "korean-word-1", "korean-resource-1", language: "Korean");
+        SeedOrphanWord("brot-word", language: "German");
+
+        SeedProgress(Captain, "korean-word-1");
+        SeedProgress(Captain, "brot-word"); // <-- the Brot scenario
+
+        var due = await _progressRepo.GetDueVocabularyAsync(DateTime.UtcNow, Captain);
+
+        due.Should().HaveCount(1, "the German orphan must NOT appear in due review — it has no reachable mapping");
+        due.Single().VocabularyWordId.Should().Be("korean-word-1");
+    }
+
+    [Fact]
+    public async Task GetDueVocabularyAsync_ExcludesProgressMappedOnlyToOtherUsersResources()
+    {
+        // A word is mapped via a resource owned by OTHER user. Captain has progress for it
+        // (e.g. legacy data, or another bug). Without the reachability filter scoped to
+        // Captain's resources, this would leak across tenants.
+        SeedReachableWord(OtherUser, "shared-word", "other-resource", language: "Korean");
+        SeedProgress(Captain, "shared-word"); // Captain has progress but cannot reach via own resources
+
+        var due = await _progressRepo.GetDueVocabularyAsync(DateTime.UtcNow, Captain);
+
+        due.Should().BeEmpty("the word is only reachable via OTHER user's resource — Captain must not see it");
+    }
+
+    [Fact]
+    public async Task GetDueVocabCountAsync_ExcludesOrphanProgressWithNoUserMapping()
+    {
+        SeedReachableWord(Captain, "korean-word-1", "korean-resource-1");
+        SeedOrphanWord("brot-word", language: "German");
+        SeedProgress(Captain, "korean-word-1");
+        SeedProgress(Captain, "brot-word");
+
+        var count = await _progressRepo.GetDueVocabCountAsync(DateTime.UtcNow, Captain);
+
+        count.Should().Be(1, "due count must match due list — orphans excluded from both");
+    }
+
+    [Fact]
+    public async Task GetDueVocabularyAsync_WithEmptyUserId_ReturnsEmpty()
+    {
+        SeedReachableWord(Captain, "w1", "r1");
+        SeedProgress(Captain, "w1");
+
+        var due = await _progressRepo.GetDueVocabularyAsync(DateTime.UtcNow, userId: "");
+
+        // Active profile in mock prefs = Captain, so resolved userId is Captain → returns 1.
+        // The empty-userId guard kicks in only when neither explicit nor preference resolves.
+        due.Should().HaveCount(1, "empty userId resolves via IPreferencesService");
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // DeleteResourceAsync orphan sweep
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteResourceAsync_RemovesProgressForWordsThatLoseLastUserMapping()
+    {
+        // Setup: resource R1 maps to W1; Captain has progress on W1.
+        SeedReachableWord(Captain, "w1", "r1");
+        SeedProgress(Captain, "w1");
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            db.VocabularyProgresses.Count(p => p.UserId == Captain).Should().Be(1);
+        }
+
+        // Act: delete R1.
+        var resource = await GetResource("r1");
+        var deleted = await _resourceRepo.DeleteResourceAsync(resource);
+
+        // Assert: progress on W1 is gone because no other resource of Captain maps to W1.
+        deleted.Should().BeGreaterThan(0);
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            db.VocabularyProgresses.Count(p => p.UserId == Captain).Should().Be(0,
+                "removing the last reachable resource must sweep its orphaned progress");
+        }
+    }
+
+    [Fact]
+    public async Task DeleteResourceAsync_KeepsProgressForWordsStillReachableViaOtherUserResource()
+    {
+        // W1 is mapped from BOTH R1 and R2 (both owned by Captain). Deleting R1 leaves W1
+        // still reachable via R2 → progress must survive.
+        SeedReachableWord(Captain, "w1", "r1");
+        AddAdditionalMapping(Captain, "w1", "r2"); // second resource maps to same word
+        SeedProgress(Captain, "w1");
+
+        var r1 = await GetResource("r1");
+        var deleted = await _resourceRepo.DeleteResourceAsync(r1);
+        deleted.Should().BeGreaterThan(0);
+
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.VocabularyProgresses.Count(p => p.UserId == Captain).Should().Be(1,
+            "progress must survive — word is still reachable via another resource");
+    }
+
+    [Fact]
+    public async Task DeleteResourceAsync_DoesNotTouchProgressOfOtherUsers()
+    {
+        // Captain and OtherUser both have their own resource mapping to the SAME global word.
+        // Captain deletes Captain's resource → only Captain's progress is swept.
+        SeedReachableWord(Captain, "w1", "captain-r1");
+        AddAdditionalMapping(OtherUser, "w1", "other-r1");
+        SeedProgress(Captain, "w1");
+        SeedProgress(OtherUser, "w1");
+
+        var captainR1 = await GetResource("captain-r1");
+        await _resourceRepo.DeleteResourceAsync(captainR1);
+
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.VocabularyProgresses.Count(p => p.UserId == Captain).Should().Be(0,
+            "Captain's progress should be swept");
+        db.VocabularyProgresses.Count(p => p.UserId == OtherUser).Should().Be(1,
+            "OtherUser's progress on the shared word must be preserved");
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // GetVocabSummaryCountsAsync reachability filter (Brot dashboard counters)
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetVocabSummaryCountsAsync_ExcludesOrphanProgressFromCounts()
+    {
+        // Captain has 1 reachable Korean word with progress, plus 1 orphan German progress
+        // row left over from a deleted resource. The orphan must NOT inflate any counter.
+        SeedReachableWord(Captain, "korean-word-1", "korean-resource-1", language: "Korean");
+        SeedOrphanWord("brot-word", language: "German");
+        SeedProgress(Captain, "korean-word-1");
+        SeedProgress(Captain, "brot-word"); // orphan — must be excluded
+
+        var (newCount, learning, familiar, review, known) =
+            await _progressRepo.GetVocabSummaryCountsAsync(Captain);
+
+        // SeedProgress defaults: TotalAttempts=5, MasteryScore=0.5, IsKnown=false,
+        // NextReviewDate=now-100days, IsUserDeclared=false → "Review" bucket.
+        review.Should().Be(1, "only the reachable Korean word should be in Review");
+        learning.Should().Be(0);
+        familiar.Should().Be(0);
+        known.Should().Be(0);
+        // totalVocabWords counts mapped distinct words for Captain = 1 (Korean only).
+        // wordsWithProgress (after reachability filter) = 1 → wordsNeverSeen = 0.
+        newCount.Should().Be(0, "wordsNeverSeen math must not be inflated by orphans");
+    }
+
+    [Fact]
+    public async Task GetVocabSummaryCountsAsync_WithEmptyResolvedUserId_ReturnsZeros()
+    {
+        // Build a separate fixture whose preferences return empty so resolution truly fails.
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var mockPrefs = new Mock<IPreferencesService>();
+        mockPrefs.Setup(p => p.Get("active_profile_id", string.Empty)).Returns(string.Empty);
+        var mockFs = new Mock<IFileSystemService>();
+        mockFs.Setup(f => f.AppDataDirectory).Returns(Path.GetTempPath());
+
+        var services = new ServiceCollection();
+        services.AddDbContext<ApplicationDbContext>(opts => opts.UseSqlite(connection));
+        services.AddSingleton<IPreferencesService>(mockPrefs.Object);
+        services.AddSingleton<IFileSystemService>(mockFs.Object);
+        using var sp = services.BuildServiceProvider();
+        using (var scope = sp.CreateScope())
+            scope.ServiceProvider.GetRequiredService<ApplicationDbContext>().Database.EnsureCreated();
+
+        var repo = new VocabularyProgressRepository(sp, NullLogger<VocabularyProgressRepository>.Instance);
+
+        var counts = await repo.GetVocabSummaryCountsAsync(userId: "");
+
+        counts.Should().Be((0, 0, 0, 0, 0), "no active user must return zeros, not aggregate across all users");
+
+        connection.Dispose();
+    }
+
+    private async Task<LearningResource> GetResource(string id)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return await db.LearningResources.SingleAsync(r => r.Id == id);
+    }
+
+    private void AddAdditionalMapping(string userId, string wordId, string resourceId)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        if (!db.LearningResources.Any(r => r.Id == resourceId))
+        {
+            db.LearningResources.Add(new LearningResource
+            {
+                Id = resourceId,
+                UserProfileId = userId,
+                Title = $"Resource {resourceId}",
+                Language = "Korean",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            });
+        }
+        db.ResourceVocabularyMappings.Add(new ResourceVocabularyMapping
+        {
+            Id = Guid.NewGuid().ToString(),
+            ResourceId = resourceId,
+            VocabularyWordId = wordId
+        });
+        db.SaveChanges();
+    }
+}


### PR DESCRIPTION
## Summary

A German word ("Brot") appeared in Captain's Korean-only Today Plan and Flashcard Preview on production webapp. Root cause: 47 German + 7 Spanish orphaned `VocabularyProgress` rows left over from a February 2026 resource delete, plus stale narrative caching that let a content-hashed `PlanItemId` from a prior plan-gen pass survive after the canonical pass replaced it.

## Production data already cleaned

54 orphan progress rows + 2 stale completion rows DELETE'd in transaction on 2026-06-12 (CoreSync triggers verified to fire — 64 `VocabularyLearningContext` cascade rows generated). Webapp container restarted to flush in-memory cache. This PR prevents recurrence.

## Two root causes, both addressed

### Bug B (root) — orphans were reachable to plan generation
`GetDueVocabularyAsync` / `GetDueVocabCountAsync` / `GetVocabSummaryCountsAsync` filtered by `UserId` only. Now they require the word be reachable via `ResourceVocabularyMapping → LearningResource(UserProfileId=user)`. `DeleteResourceAsync` now sweeps the owner user's progress rows that lost their last reachable mapping (per-user scoped — never touches other users' progress on globally-shared `VocabularyWord` rows).

### Bug A (compounder) — stale narrative survived plan re-generation
`InitializePlanCompletionRecordsAsync` was INSERT-only. With content-hashed `PlanItemId`, two plan-gen passes produced two sets of completion rows; `ReconstructPlanFromDatabase` then surfaced the older narrative. Now REFRESH-existing (preserves user-progress fields), with orphan sweep for IDs no longer in the plan AND with zero progress. `ReconstructPlanFromDatabase` also reads the freshest row by `UpdatedAt DESC` as defense in depth.

### Bonus latent fixes surfaced by skeptic + code-review

- `GenerateTodaysPlanAsync` now serializes cache-miss → LLM call via a per-user `SemaphoreSlim` (bounded `ConcurrentDictionary` keyed on userId). Closes the race that let two simultaneous Blazor circuits / sync passes both generate a plan.
- `ProgressCacheService` swapped 5 `Dictionary<>` → `ConcurrentDictionary<>` (latent race: Singleton service).
- Multi-tenant empty-userId guards added per repo scoping rule.
- `existing.Rationale = plan.Rationale ?? existing.Rationale` (was `?? string.Empty` — would wipe rationale on null).

## Tests

9 regression tests in `BrotOrphanProgressRegressionTests` covering reachability filters, cascade orphan sweep with per-user scope, empty-userId guards. Full suite: **600/600 passing** (591 baseline + 9 new).

## Validation

- Build clean: Shared (net10.0/net11.0-ios/net11.0-maccatalyst), API, WebApp, UnitTests
- Production already verified post-cleanup: Captain's Today Plan = 3 clean Korean-only rows, Brot absent from all completion narratives
- Code-review agent (2 passes): all findings applied, final pass clean

## Refs
- Brot incident, 2026-06-12
- Session checkpoint 023 (skeptic review with 4 BLOCKER findings — all 4 addressed)
- Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>