### PR TITLE
Clear PendingRecognitionCheck unconditionally on vocab quiz override

### DIFF
--- a/src/SentenceStudio.Shared/Models/VocabularyQuizItem.cs
+++ b/src/SentenceStudio.Shared/Models/VocabularyQuizItem.cs
@@ -81,6 +81,43 @@ public class VocabularyQuizItem
     public bool IsReadyToSkipInCurrentPhase { get; set; }
     public bool WasCorrectThisSession { get; set; }
 
+    /// <summary>
+    /// Apply the in-session state mutations that happen when the user marks
+    /// a graded-wrong answer as correct via the "I was correct" override.
+    ///
+    /// Shared by VocabQuiz.razor's OverrideAsCorrect and the regression tests
+    /// in VocabQuizOverrideRegressionTests so a future regression on
+    /// PendingRecognitionCheck clearing is caught by the test suite, not just
+    /// by Captain reporting the bug again.
+    ///
+    /// IMPORTANT: PendingRecognitionCheck must be cleared for BOTH modes.
+    /// The wrong-text demotion to MC never should have fired once the user
+    /// confirmed they were correct — leaving the flag true forces the same
+    /// word back into MC on its next session appearance with a debug pane
+    /// reading "Recognition check (wrong text answer earlier)". See Captain's
+    /// 2026-06-12 report and VocabQuizOverrideRegressionTests.
+    ///
+    /// Does NOT touch persistence — the caller is responsible for mutating
+    /// the deferred pending attempt's WasCorrect and calling the persistence
+    /// service. This method only handles the in-memory session model.
+    /// </summary>
+    /// <param name="userMode">"MultipleChoice" or "Text" — the mode the
+    /// override was issued from.</param>
+    public void ApplyOverrideAsCorrect(string userMode)
+    {
+        SessionCorrectCount++;
+        if (userMode == "MultipleChoice")
+            SessionMCCorrect++;
+        else
+            SessionTextCorrect++;
+
+        // Override means the user WAS correct — clear the gentle-demotion
+        // flag for either mode so the same word does not cycle back as a
+        // forced MC "recognition check" in the same session.
+        PendingRecognitionCheck = false;
+        WasCorrectThisSession = true;
+    }
+
     // Status helpers
     public bool IsUnknown => Progress?.IsUnknown ?? true;
     public bool IsLearning => Progress?.IsLearning ?? false;

--- a/src/SentenceStudio.UI/Pages/VocabQuiz.razor
+++ b/src/SentenceStudio.UI/Pages/VocabQuiz.razor
@@ -1390,20 +1390,10 @@ else
         requireCorrectTyping = false;
         feedbackMessage = "Marked correct ✓";
 
-        // Update session counters (override counts as correct)
-        currentItem.SessionCorrectCount++;
-        if (userMode == "MultipleChoice")
-        {
-            currentItem.SessionMCCorrect++;
-            currentItem.PendingRecognitionCheck = false;
-        }
-        else
-        {
-            currentItem.SessionTextCorrect++;
-        }
-
-        // Fix 1: Also mark as correct in session
-        currentItem.WasCorrectThisSession = true;
+        // Apply session-state mutations via the shared method on
+        // VocabularyQuizItem so the regression tests bind to the same code.
+        // Clears PendingRecognitionCheck for both modes — see method docs.
+        currentItem.ApplyOverrideAsCorrect(userMode);
 
         // Update the deferred attempt to correct and persist it
         if (pendingAttempt != null)

--- a/tests/SentenceStudio.UnitTests/Integration/VocabQuizOverrideRegressionTests.cs
+++ b/tests/SentenceStudio.UnitTests/Integration/VocabQuizOverrideRegressionTests.cs
@@ -1,0 +1,153 @@
+// REGRESSION TESTS — "I was correct" override on a wrong text answer must NOT
+// leave the word in PendingRecognitionCheck state, otherwise the SAME word
+// cycles back as a forced MultipleChoice with the debug pane reading
+// "Recognition check (wrong text answer earlier)". Captain's report 2026-06-12:
+//
+//   "I answered a text entry vocab quiz that was marked incorrect due to a
+//    typo, so I marked it 'I was correct' twice. The next time that word
+//    appeared it reverted back to multiple choice telling me I'd been
+//    penalized. That should not have happened!"
+//
+// Root cause: VocabQuiz.razor's SubmitAnswer set PendingRecognitionCheck=true
+// on the wrong-text branch (line 1227) as a "gentle demotion". OverrideAsCorrect
+// only cleared PendingRecognitionCheck in the MultipleChoice branch; the Text
+// branch left the flag set, so the next time the word appeared in the same
+// session, the mode-selector forced MultipleChoice.
+//
+// Fix: clear PendingRecognitionCheck unconditionally inside
+// VocabularyQuizItem.ApplyOverrideAsCorrect, which is the shared production
+// method called by both VocabQuiz.razor's OverrideAsCorrect and these tests.
+//
+// If this test fails, the override regression is back. DO NOT DELETE OR WEAKEN.
+
+using FluentAssertions;
+using SentenceStudio.Shared.Models;
+using Xunit;
+
+namespace SentenceStudio.UnitTests.Integration;
+
+public class VocabQuizOverrideRegressionTests
+{
+    /// <summary>
+    /// Mirror of VocabQuiz.razor's mode-selector (lines 829-839):
+    ///   PendingRecognitionCheck → MultipleChoice
+    ///   CurrentStreak >= 3 OR MasteryScore >= 0.50 → Text
+    ///   else → MultipleChoice
+    /// </summary>
+    private static string ChooseQuizModeForTurn(VocabularyQuizItem item)
+    {
+        if (item.PendingRecognitionCheck) return "MultipleChoice";
+        var streak = item.Progress?.CurrentStreak ?? 0f;
+        var mastery = item.Progress?.MasteryScore ?? 0f;
+        return (streak >= 3f || mastery >= 0.50f) ? "Text" : "MultipleChoice";
+    }
+
+    /// <summary>
+    /// Mirror the state mutations that VocabQuiz.razor SubmitAnswer performs
+    /// for a wrong text answer. See VocabQuiz.razor lines 1223-1232.
+    /// </summary>
+    private static void ApplyWrongTextAnswer(VocabularyQuizItem item)
+    {
+        // Wrong text answer → gentle demotion: force MC next appearance.
+        item.PendingRecognitionCheck = true;
+        // Wrong answer does not increment any session-correct counter.
+    }
+
+    [Fact]
+    public void Override_AfterWrongTextAnswer_ClearsPendingRecognitionCheck()
+    {
+        // Captain's scenario: word was already known well enough for Text mode
+        // (MasteryScore = 0.6 puts the mode-selector into Text), user typoed,
+        // grader scored wrong (sets PendingRecognitionCheck), user overrides
+        // via "I was correct".
+        var item = new VocabularyQuizItem
+        {
+            Word = new VocabularyWord { Id = "w1", TargetLanguageTerm = "사과" },
+            Progress = new VocabularyProgress
+            {
+                VocabularyWordId = "w1",
+                UserId = "captain",
+                MasteryScore = 0.60f,
+                CurrentStreak = 3f
+            }
+        };
+
+        // Turn 1 — Text mode (mastery >= 0.50), wrong answer.
+        ChooseQuizModeForTurn(item).Should().Be("Text", "starting mastery puts the user in Text mode");
+        ApplyWrongTextAnswer(item);
+
+        item.PendingRecognitionCheck.Should().BeTrue(
+            "wrong text answer sets the gentle-demotion flag");
+
+        // User overrides — calls the PRODUCTION method on VocabularyQuizItem.
+        item.ApplyOverrideAsCorrect(userMode: "Text");
+
+        // Post-condition: the flag must be cleared. Next-turn mode selection
+        // for the SAME word must NOT force MultipleChoice.
+        item.PendingRecognitionCheck.Should().BeFalse(
+            "override means the system was wrong to set the demotion — flag must be cleared");
+
+        ChooseQuizModeForTurn(item).Should().Be("Text",
+            "after override, the same word must continue in Text mode — NOT revert to "
+          + "MultipleChoice as a 'recognition check' for a wrong answer that the user "
+          + "self-corrected. See vocab quiz override bug, 2026-06-12.");
+    }
+
+    [Fact]
+    public void Override_AfterTwoConsecutiveWrongTextAnswers_StillClearsPendingRecognitionCheck()
+    {
+        // Captain explicitly said he overrode "twice" — make sure repeated
+        // wrong-then-override cycles still leave the flag cleared.
+        var item = new VocabularyQuizItem
+        {
+            Word = new VocabularyWord { Id = "w1", TargetLanguageTerm = "사과" },
+            Progress = new VocabularyProgress
+            {
+                VocabularyWordId = "w1",
+                UserId = "captain",
+                MasteryScore = 0.60f,
+                CurrentStreak = 3f
+            }
+        };
+
+        // Cycle 1: wrong → override.
+        ApplyWrongTextAnswer(item);
+        item.ApplyOverrideAsCorrect(userMode: "Text");
+        item.PendingRecognitionCheck.Should().BeFalse();
+
+        // Cycle 2: wrong → override.
+        ApplyWrongTextAnswer(item);
+        item.ApplyOverrideAsCorrect(userMode: "Text");
+        item.PendingRecognitionCheck.Should().BeFalse();
+
+        // Next mode pick still respects mastery, not the prior wrong attempts.
+        ChooseQuizModeForTurn(item).Should().Be("Text");
+
+        // Session counters reflect two overrides.
+        item.SessionCorrectCount.Should().Be(2);
+        item.SessionTextCorrect.Should().Be(2);
+    }
+
+    [Fact]
+    public void Override_AfterWrongMultipleChoiceAnswer_StillClearsPendingRecognitionCheck()
+    {
+        // Belt-and-suspenders for the pre-existing MC branch behavior: when in
+        // MC mode, overriding must still clear the flag (the production code
+        // already did this; this test pins the contract).
+        var item = new VocabularyQuizItem
+        {
+            Word = new VocabularyWord { Id = "w1", TargetLanguageTerm = "사과" },
+            Progress = new VocabularyProgress
+            {
+                VocabularyWordId = "w1",
+                UserId = "captain"
+            },
+            PendingRecognitionCheck = true // simulate prior wrong text answer earlier in session
+        };
+
+        item.ApplyOverrideAsCorrect(userMode: "MultipleChoice");
+
+        item.PendingRecognitionCheck.Should().BeFalse();
+        item.SessionMCCorrect.Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Bug

Captain reported 2026-06-12:

> I answered a text entry vocab quiz that was marked incorrect due to a typo, so I marked it 'I was correct' twice. The next time that word appeared it reverted back to multiple choice telling me I'd been penalized. That should not have happened!

## Root cause

`VocabQuiz.razor::OverrideAsCorrect` cleared `currentItem.PendingRecognitionCheck = false` **only inside the `if (userMode == "MultipleChoice")` branch**. The Text branch left the flag set, so the mode-selector at line 831 forced MC on the same word's next session appearance. The **persisted** attempt was already correctly mutated to `WasCorrect=true` (line 1416), so mastery was NOT penalized — only the session-local UI demotion stuck.

## Fix

Extracted the in-session state mutations into `VocabularyQuizItem.ApplyOverrideAsCorrect(string userMode)`. Both the Blazor page and the regression tests now call the **same production method**, so a future regression on the unconditional `PendingRecognitionCheck` clearing will fail the test suite.

Persistence path (`pendingAttempt.WasCorrect` mutation + `RecordPendingAttemptAsync`) is unchanged.

## Tests

`VocabQuizOverrideRegressionTests` — 3 tests, pure in-memory `VocabularyQuizItem` (no DB, no Blazor):

1. `Override_AfterWrongTextAnswer_ClearsPendingRecognitionCheck` — primary repro.
2. `Override_AfterTwoConsecutiveWrongTextAnswers_StillClearsPendingRecognitionCheck` — Captain's "twice".
3. `Override_AfterWrongMultipleChoiceAnswer_StillClearsPendingRecognitionCheck` — pins pre-existing MC contract.

**Verified:** 603/603 unit tests pass (600 baseline + 3 new).

**Teeth verified:** temporarily removed `PendingRecognitionCheck = false` from `ApplyOverrideAsCorrect` → all 3 tests failed. Restored → all pass. The tests bind to real production code, not a hand-copied helper.

## Post-merge

- `azd deploy` + `./scripts/post-deploy-validate.sh`.
- E2E in production webapp: typo a text-mode word, click "I was correct", confirm next appearance of the same word stays in Text mode (not forced MC with "Recognition check (wrong text answer earlier)").

## Follow-up (separate PR)

`.squad/skills/grader-override-pattern/SKILL.md` claims override is "UI-only / does not change past data" — stale; the actual code mutates `pendingAttempt.WasCorrect = true` and persists it. Doc cleanup worth doing on its own.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>