### PR TITLE
Preserve & recalculate learning history on vocab merge + word-page history UI

### DIFF
--- a/src/SentenceStudio.Shared/Data/LearningResourceRepository.cs
+++ b/src/SentenceStudio.Shared/Data/LearningResourceRepository.cs
@@ -1206,12 +1206,24 @@ public class LearningResourceRepository
     }
 
     /// <summary>
-    /// Merge duplicate vocabulary words: reassign all resource mappings from source words
-    /// to the keeper word, then delete the source words.
+    /// Merge duplicate vocabulary words into the keeper. Reassigns all resource mappings, then — critically —
+    /// PRESERVES learning history: every <see cref="VocabularyProgress"/> and per-attempt
+    /// <see cref="VocabularyLearningContext"/> belonging to a duplicate is folded into the keeper instead of
+    /// being destroyed by the database's ON DELETE CASCADE.
+    ///
+    /// Mastery is recalculated "as if it had always been one word" by re-parenting every learning context to
+    /// the keeper and replaying them chronologically through <see cref="VocabularyMasteryCalculator"/> (the same
+    /// engine the live attempt path uses). Progress is merged PER USER — each user keeps exactly one combined
+    /// keeper record; users are never collapsed together.
     /// </summary>
     public async Task<int> MergeVocabularyWordsAsync(string keeperWordId, List<string> deleteWordIds)
     {
         if (string.IsNullOrWhiteSpace(keeperWordId) || deleteWordIds == null || !deleteWordIds.Any())
+            return 0;
+
+        // Never let the keeper appear in its own delete list.
+        deleteWordIds = deleteWordIds.Where(id => !string.IsNullOrWhiteSpace(id) && id != keeperWordId).Distinct().ToList();
+        if (!deleteWordIds.Any())
             return 0;
 
         using var scope = _serviceProvider.CreateScope();
@@ -1245,8 +1257,15 @@ public class LearningResourceRepository
                 }
                 db.ResourceVocabularyMappings.Remove(mapping);
             }
+        }
 
-            // Delete the duplicate word
+        // Preserve + recombine learning history before the words (and their cascade) are removed.
+        await MergeLearningProgressAsync(db, keeperWordId, deleteWordIds);
+
+        foreach (var deleteId in deleteWordIds)
+        {
+            // Delete the duplicate word. Any progress/context rows that still reference it have already
+            // been re-parented to the keeper above, so the cascade has nothing left to destroy.
             var word = await db.VocabularyWords.FindAsync(deleteId);
             if (word != null)
             {
@@ -1257,10 +1276,181 @@ public class LearningResourceRepository
 
         if (deleted > 0)
         {
+            // Single SaveChanges => EF wraps everything (mapping reassignment, history merge, word deletes)
+            // in one transaction. EF's FK-aware command ordering updates the re-parented contexts before
+            // deleting the old duplicate progress rows, so no learning history is lost to the cascade.
             await db.SaveChangesAsync();
             _syncService?.TriggerSyncAsync().ConfigureAwait(false);
         }
 
         return deleted;
+    }
+
+    /// <summary>
+    /// Folds the learning progress and per-attempt contexts of the duplicate words into the keeper, per user.
+    /// Mutates the tracked <paramref name="db"/> graph only; the caller owns the single SaveChanges.
+    /// </summary>
+    private async Task MergeLearningProgressAsync(ApplicationDbContext db, string keeperWordId, List<string> deleteWordIds)
+    {
+        var allWordIds = new List<string>(deleteWordIds) { keeperWordId };
+
+        // Load tracked so mutations + re-parenting flush on the caller's SaveChanges.
+        var allProgresses = await db.VocabularyProgresses
+            .Where(p => allWordIds.Contains(p.VocabularyWordId))
+            .ToListAsync();
+
+        if (allProgresses.Count == 0)
+            return; // No practiced history on any of these words — nothing to preserve.
+
+        var progressIds = allProgresses.Select(p => p.Id).ToList();
+        var allContexts = await db.VocabularyLearningContexts
+            .Where(c => progressIds.Contains(c.VocabularyProgressId))
+            .ToListAsync();
+
+        var contextsByProgress = allContexts
+            .GroupBy(c => c.VocabularyProgressId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        int usersMerged = 0;
+        int contextsReparented = 0;
+
+        foreach (var userGroup in allProgresses.GroupBy(p => p.UserId))
+        {
+            var userId = userGroup.Key;
+            var userProgresses = userGroup.ToList();
+            var keeperProg = userProgresses.FirstOrDefault(p => p.VocabularyWordId == keeperWordId);
+            var dupProgresses = userProgresses.Where(p => p.VocabularyWordId != keeperWordId).ToList();
+
+            if (dupProgresses.Count == 0)
+                continue; // This user only had keeper progress — already correct, leave untouched.
+
+            // Every learning context belonging to this user across keeper + duplicates.
+            var userContexts = userProgresses
+                .SelectMany(p => contextsByProgress.TryGetValue(p.Id, out var list) ? list : Enumerable.Empty<VocabularyLearningContext>())
+                .ToList();
+
+            // Pre-merge aggregates — used to reconcile so counts/dates never regress, even for ancient
+            // history that predates per-attempt context tracking (where replay alone would undercount).
+            int summedTotal = userProgresses.Sum(p => p.TotalAttempts);
+            int summedCorrect = userProgresses.Sum(p => p.CorrectAttempts);
+            int summedExposure = userProgresses.Sum(p => p.ExposureCount);
+            // Best mastery/streak across sources — used only to prevent regression when source history
+            // predates per-attempt context tracking (so replay cannot fully reconstruct it).
+            float maxSourceMastery = userProgresses.Max(p => p.MasteryScore);
+            float maxSourceStreak = userProgresses.Max(p => p.CurrentStreak);
+            int maxSourceProductionInStreak = userProgresses.Max(p => p.ProductionInStreak);
+            DateTime minFirstSeen = userProgresses.Min(p => p.FirstSeenAt);
+            DateTime minCreated = userProgresses.Min(p => p.CreatedAt);
+            DateTime maxLastPracticed = userProgresses.Max(p => p.LastPracticedAt);
+            DateTime? maxLastExposed = userProgresses
+                .Where(p => p.LastExposedAt.HasValue)
+                .Select(p => (DateTime?)p.LastExposedAt!.Value)
+                .Max();
+            DateTime? earliestMastered = userProgresses
+                .Where(p => p.MasteredAt.HasValue)
+                .Select(p => (DateTime?)p.MasteredAt!.Value)
+                .Min();
+            var declared = userProgresses
+                .Where(p => p.IsUserDeclared)
+                .OrderByDescending(p => p.UserDeclaredAt ?? DateTime.MinValue)
+                .FirstOrDefault();
+            // Most-recently-practiced source's spaced-repetition schedule. Used only to restore the SR
+            // cadence when replay cannot reconstruct it (aggregate-only legacy history with no contexts),
+            // so a merged word still resurfaces for review on time instead of going dormant.
+            var scheduleSource = userProgresses
+                .Where(p => p.NextReviewDate.HasValue)
+                .OrderByDescending(p => p.LastPracticedAt)
+                .FirstOrDefault()
+                ?? userProgresses.OrderByDescending(p => p.LastPracticedAt).First();
+
+            bool createdKeeper = keeperProg == null;
+            if (createdKeeper)
+            {
+                // This user practiced a duplicate but never the keeper word — give them a keeper record.
+                keeperProg = new VocabularyProgress
+                {
+                    VocabularyWordId = keeperWordId,
+                    UserId = userId
+                };
+                db.VocabularyProgresses.Add(keeperProg);
+            }
+
+            // Recalculate mastery as if all of this user's contexts had always belonged to the keeper.
+            VocabularyMasteryCalculator.RecalculateInto(keeperProg!, userContexts, out _);
+
+            // Number of active attempts the replay actually reconstructed (= keeper.TotalAttempts before
+            // count reconciliation). When this is less than the summed aggregate, source history predates
+            // per-attempt context tracking and replay is incomplete.
+            int replayedActiveAttempts = keeperProg!.TotalAttempts;
+            bool hasPreContextHistory = summedTotal > replayedActiveAttempts;
+
+            // Reconcile so the merge is monotonic — never lose attempts, exposures, or historical dates.
+            keeperProg.TotalAttempts = Math.Max(keeperProg.TotalAttempts, summedTotal);
+            keeperProg.CorrectAttempts = Math.Min(keeperProg.TotalAttempts, Math.Max(keeperProg.CorrectAttempts, summedCorrect));
+            keeperProg.ExposureCount = Math.Max(keeperProg.ExposureCount, summedExposure);
+
+            // For fully context-backed (modern) data the replay is exact and authoritative, so the wrong
+            // answers it replays are allowed to lower mastery — that's the faithful "as if one word" result.
+            // Only when there's a pre-context gap do we protect against regressing below the best source,
+            // otherwise ancient words (aggregate-only, no contexts) would be wrongly reset toward Unknown.
+            if (hasPreContextHistory)
+            {
+                keeperProg.MasteryScore = Math.Max(keeperProg.MasteryScore, maxSourceMastery);
+                keeperProg.CurrentStreak = Math.Max(keeperProg.CurrentStreak, maxSourceStreak);
+                keeperProg.ProductionInStreak = Math.Max(keeperProg.ProductionInStreak, maxSourceProductionInStreak);
+            }
+
+            // Replay resets the SR schedule to defaults (NextReviewDate=null, Interval=1, Ease=2.5). When it
+            // reconstructed at least one active attempt, that replayed schedule reflects the most recent
+            // context-backed attempt and is authoritative — leave it. When replay produced no active attempts
+            // (aggregate-only legacy data, or a user-declared "Familiar" duplicate that was never quizzed) the
+            // replayed schedule is still the default, so carry a real source schedule forward — otherwise the
+            // merged word would have NextReviewDate=null and never become due (IsDueForReview) again.
+            if (replayedActiveAttempts == 0 && scheduleSource.NextReviewDate.HasValue)
+            {
+                keeperProg.NextReviewDate = scheduleSource.NextReviewDate;
+                keeperProg.ReviewInterval = scheduleSource.ReviewInterval;
+                keeperProg.EaseFactor = scheduleSource.EaseFactor;
+            }
+
+            keeperProg.FirstSeenAt = minFirstSeen;
+            keeperProg.CreatedAt = minCreated;
+            if (maxLastPracticed > keeperProg.LastPracticedAt)
+                keeperProg.LastPracticedAt = maxLastPracticed;
+            if (maxLastExposed.HasValue && (!keeperProg.LastExposedAt.HasValue || maxLastExposed > keeperProg.LastExposedAt))
+                keeperProg.LastExposedAt = maxLastExposed;
+            // MasteredAt is a historical "first reached mastery" fact; keep the earliest known date.
+            if (earliestMastered.HasValue && (!keeperProg.MasteredAt.HasValue || earliestMastered < keeperProg.MasteredAt))
+                keeperProg.MasteredAt = earliestMastered;
+            // Carry an explicit user declaration ("I know this word") — strong signal we must not drop.
+            if (declared != null)
+            {
+                keeperProg.IsUserDeclared = true;
+                keeperProg.UserDeclaredAt = declared.UserDeclaredAt;
+                keeperProg.VerificationState = declared.VerificationState;
+            }
+            keeperProg.UpdatedAt = DateTime.Now;
+
+            // Re-parent every duplicate context onto the keeper BEFORE the duplicate progress rows are
+            // removed, so the database cascade has no children left to delete.
+            foreach (var ctx in userContexts.Where(c => c.VocabularyProgressId != keeperProg.Id))
+            {
+                ctx.VocabularyProgressId = keeperProg.Id;
+                ctx.UpdatedAt = DateTime.Now;
+                contextsReparented++;
+            }
+
+            foreach (var dp in dupProgresses)
+                db.VocabularyProgresses.Remove(dp);
+
+            usersMerged++;
+        }
+
+        if (usersMerged > 0)
+        {
+            _logger.LogInformation(
+                "Vocab merge: folded learning history into keeper {KeeperWordId} for {UserCount} user(s), re-parented {ContextCount} learning context(s) from {DuplicateCount} duplicate word(s).",
+                keeperWordId, usersMerged, contextsReparented, deleteWordIds.Count);
+        }
     }
 }

--- a/src/SentenceStudio.Shared/Resources/Strings/AppResources.Designer.cs
+++ b/src/SentenceStudio.Shared/Resources/Strings/AppResources.Designer.cs
@@ -13656,6 +13656,87 @@ namespace SentenceStudio.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Mastery over time.
+        /// </summary>
+        internal static string VocabWordEdit_HistoryChartAria {
+            get {
+                return ResourceManager.GetString("VocabWordEdit_HistoryChartAria", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Correct.
+        /// </summary>
+        internal static string VocabWordEdit_HistoryCorrect {
+            get {
+                return ResourceManager.GetString("VocabWordEdit_HistoryCorrect", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No practice attempts recorded yet. Start practicing to build a history..
+        /// </summary>
+        internal static string VocabWordEdit_HistoryEmpty {
+            get {
+                return ResourceManager.GetString("VocabWordEdit_HistoryEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exposure.
+        /// </summary>
+        internal static string VocabWordEdit_HistoryExposure {
+            get {
+                return ResourceManager.GetString("VocabWordEdit_HistoryExposure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Incorrect.
+        /// </summary>
+        internal static string VocabWordEdit_HistoryIncorrect {
+            get {
+                return ResourceManager.GetString("VocabWordEdit_HistoryIncorrect", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Known (85%).
+        /// </summary>
+        internal static string VocabWordEdit_HistoryKnownLine {
+            get {
+                return ResourceManager.GetString("VocabWordEdit_HistoryKnownLine", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Practice.
+        /// </summary>
+        internal static string VocabWordEdit_HistoryPractice {
+            get {
+                return ResourceManager.GetString("VocabWordEdit_HistoryPractice", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} attempts · {1} exposures.
+        /// </summary>
+        internal static string VocabWordEdit_HistorySummary {
+            get {
+                return ResourceManager.GetString("VocabWordEdit_HistorySummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Practice History.
+        /// </summary>
+        internal static string VocabWordEdit_HistoryTitle {
+            get {
+                return ResourceManager.GetString("VocabWordEdit_HistoryTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Known.
         /// </summary>
         internal static string VocabWordEdit_Known {

--- a/src/SentenceStudio.Shared/Resources/Strings/AppResources.ko.resx
+++ b/src/SentenceStudio.Shared/Resources/Strings/AppResources.ko.resx
@@ -3841,6 +3841,42 @@
     <value>학습 진행 상황</value>
     <comment>Section heading</comment>
   </data>
+  <data name="VocabWordEdit_HistoryTitle" xml:space="preserve">
+    <value>연습 기록</value>
+    <comment>Section heading for the per-attempt learning history</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryEmpty" xml:space="preserve">
+    <value>아직 기록된 연습 시도가 없습니다. 연습을 시작하여 기록을 쌓아보세요.</value>
+    <comment>Empty state for practice history</comment>
+  </data>
+  <data name="VocabWordEdit_HistorySummary" xml:space="preserve">
+    <value>시도 {0}회 · 노출 {1}회</value>
+    <comment>History summary; {0} = attempt count, {1} = passive exposure count</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryChartAria" xml:space="preserve">
+    <value>시간에 따른 숙련도</value>
+    <comment>Accessible label for the mastery-over-time chart</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryKnownLine" xml:space="preserve">
+    <value>알고 있음 (85%)</value>
+    <comment>Label for the mastery threshold line on the chart</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryCorrect" xml:space="preserve">
+    <value>정답</value>
+    <comment>Legend / entry label for a correct attempt</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryIncorrect" xml:space="preserve">
+    <value>오답</value>
+    <comment>Legend / entry label for an incorrect attempt</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryExposure" xml:space="preserve">
+    <value>노출</value>
+    <comment>Entry label for a passive reading exposure</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryPractice" xml:space="preserve">
+    <value>연습</value>
+    <comment>Fallback activity label for a history entry</comment>
+  </data>
   <data name="VocabWordEdit_Status" xml:space="preserve">
     <value>상태</value>
     <comment>Label</comment>

--- a/src/SentenceStudio.Shared/Resources/Strings/AppResources.resx
+++ b/src/SentenceStudio.Shared/Resources/Strings/AppResources.resx
@@ -4089,6 +4089,42 @@ For example: {0} ...</value>
     <value>Learning Progress</value>
     <comment>Section heading</comment>
   </data>
+  <data name="VocabWordEdit_HistoryTitle" xml:space="preserve">
+    <value>Practice History</value>
+    <comment>Section heading for the per-attempt learning history</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryEmpty" xml:space="preserve">
+    <value>No practice attempts recorded yet. Start practicing to build a history.</value>
+    <comment>Empty state for practice history</comment>
+  </data>
+  <data name="VocabWordEdit_HistorySummary" xml:space="preserve">
+    <value>{0} attempts · {1} exposures</value>
+    <comment>History summary; {0} = attempt count, {1} = passive exposure count</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryChartAria" xml:space="preserve">
+    <value>Mastery over time</value>
+    <comment>Accessible label for the mastery-over-time chart</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryKnownLine" xml:space="preserve">
+    <value>Known (85%)</value>
+    <comment>Label for the mastery threshold line on the chart</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryCorrect" xml:space="preserve">
+    <value>Correct</value>
+    <comment>Legend / entry label for a correct attempt</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryIncorrect" xml:space="preserve">
+    <value>Incorrect</value>
+    <comment>Legend / entry label for an incorrect attempt</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryExposure" xml:space="preserve">
+    <value>Exposure</value>
+    <comment>Entry label for a passive reading exposure</comment>
+  </data>
+  <data name="VocabWordEdit_HistoryPractice" xml:space="preserve">
+    <value>Practice</value>
+    <comment>Fallback activity label for a history entry</comment>
+  </data>
   <data name="VocabWordEdit_Status" xml:space="preserve">
     <value>Status</value>
     <comment>Label</comment>

--- a/src/SentenceStudio.Shared/Services/VocabularyMasteryCalculator.cs
+++ b/src/SentenceStudio.Shared/Services/VocabularyMasteryCalculator.cs
@@ -1,0 +1,228 @@
+using SentenceStudio.Shared.Models;
+
+namespace SentenceStudio.Services;
+
+/// <summary>
+/// Pure, stateless scoring engine for vocabulary mastery. This is the single source of truth for
+/// the streak-based mastery/spaced-repetition math so that the live attempt path
+/// (<see cref="VocabularyProgressService.RecordAttemptAsync"/>), duplicate-merge recalculation
+/// (<c>LearningResourceRepository.MergeVocabularyWordsAsync</c>), and the word-page mastery chart all
+/// produce identical results.
+///
+/// "Recalculate as if it was always one word" is implemented by replaying every persisted
+/// <see cref="VocabularyLearningContext"/> (which is recorded for every attempt) in chronological
+/// order through <see cref="ApplyAttempt"/>.
+/// </summary>
+public static class VocabularyMasteryCalculator
+{
+    // Streak-based scoring constants — kept in lock-step with the values that previously lived in
+    // VocabularyProgressService. See Issue #191 for the EFFECTIVE_STREAK_DIVISOR rationale.
+    public const float MASTERY_THRESHOLD = 0.85f;
+    public const int MIN_PRODUCTION_FOR_KNOWN = 2;
+    public const float EFFECTIVE_STREAK_DIVISOR = 12.0f;
+    public const float WRONG_ANSWER_FLOOR = 0.6f;
+    public const float MAX_WRONG_PENALTY = 0.4f;
+    public const float MAX_STREAK_PRESERVE = 0.5f;
+    public const float STREAK_PRESERVE_DIVISOR = 8.0f;
+    public const float RECOVERY_BOOST = 0.02f;
+
+    private const int MAX_REVIEW_INTERVAL_DAYS = 365;
+    private const int MASTERED_REVIEW_INTERVAL_DAYS = 60;
+
+    /// <summary>
+    /// A single point on a word's mastery-over-time curve, produced by <see cref="RecalculateInto"/>.
+    /// </summary>
+    public readonly record struct MasteryTrajectoryPoint(
+        DateTime At,
+        float MasteryScore,
+        bool WasCorrect,
+        string Activity,
+        string InputMode);
+
+    /// <summary>
+    /// Applies a single attempt to the running <paramref name="progress"/> aggregate, mutating the
+    /// streak, mastery score, spaced-repetition schedule, counts, and mastery timestamps. This is the
+    /// exact core math the live attempt path uses (legacy phase metrics, passive cascade, and context
+    /// persistence remain the caller's responsibility).
+    /// </summary>
+    /// <param name="attemptTime">
+    /// Timestamp to attribute to this attempt. The live path passes <c>DateTime.Now</c>; replay passes
+    /// the historical <see cref="VocabularyLearningContext.LearnedAt"/> so reconstructed schedules and
+    /// mastery timestamps reflect when the practice actually happened.
+    /// </param>
+    public static void ApplyAttempt(VocabularyProgress progress, VocabularyAttempt attempt, DateTime attemptTime)
+    {
+        progress.TotalAttempts++;
+        if (attempt.WasCorrect)
+            progress.CorrectAttempts++;
+
+        // Production = free recall (Text/Voice input) rather than recognition (MultipleChoice).
+        // String comparison mirrors the live path exactly (InputMode.Text/Voice .ToString()).
+        bool isProduction = attempt.InputMode == "Text" ||
+                            attempt.InputMode == "Voice" ||
+                            attempt.InputMode == "TextEntry"; // Legacy support
+
+        if (attempt.WasCorrect)
+        {
+            float weight = attempt.DifficultyWeight > 0 ? attempt.DifficultyWeight : 1.0f;
+            progress.CurrentStreak += weight;
+            if (isProduction)
+            {
+                progress.ProductionInStreak++;
+            }
+
+            float effectiveStreak = progress.CurrentStreak + (progress.ProductionInStreak * 0.5f);
+            float streakScore = MathF.Min(effectiveStreak / EFFECTIVE_STREAK_DIVISOR, 1.0f);
+            float recoveryBoost = (progress.MasteryScore > streakScore) ? RECOVERY_BOOST : 0f;
+            progress.MasteryScore = MathF.Max(streakScore, progress.MasteryScore) + recoveryBoost;
+            progress.MasteryScore = MathF.Min(progress.MasteryScore, 1.0f);
+        }
+        else
+        {
+            float penaltyFactor = MathF.Max(
+                WRONG_ANSWER_FLOOR,
+                1.0f - (MAX_WRONG_PENALTY / (1f + MathF.Log(1 + progress.CorrectAttempts))));
+
+            if (attempt.PenaltyOverride.HasValue)
+            {
+                penaltyFactor = attempt.PenaltyOverride.Value;
+            }
+
+            progress.MasteryScore *= penaltyFactor;
+
+            float preserveFraction = MathF.Min(
+                MAX_STREAK_PRESERVE,
+                MathF.Log(1 + progress.CorrectAttempts) / STREAK_PRESERVE_DIVISOR);
+            progress.CurrentStreak = progress.CurrentStreak * preserveFraction;
+            progress.ProductionInStreak = (int)(progress.ProductionInStreak * preserveFraction);
+        }
+
+        UpdateSpacedRepetitionSchedule(progress, attempt.WasCorrect, attemptTime);
+
+        progress.LastPracticedAt = attemptTime;
+        progress.UpdatedAt = attemptTime;
+
+        if (progress.MasteryScore >= MASTERY_THRESHOLD &&
+            progress.ProductionInStreak >= MIN_PRODUCTION_FOR_KNOWN)
+        {
+            if (!progress.MasteredAt.HasValue)
+            {
+                progress.MasteredAt = attemptTime;
+            }
+            // Known words always get a long review interval — SM-2 would set a short one since it
+            // doesn't know about mastery status.
+            progress.ReviewInterval = MASTERED_REVIEW_INTERVAL_DAYS;
+            progress.NextReviewDate = attemptTime.AddDays(MASTERED_REVIEW_INTERVAL_DAYS);
+        }
+    }
+
+    private static void UpdateSpacedRepetitionSchedule(VocabularyProgress progress, bool wasCorrect, DateTime attemptTime)
+    {
+        if (!wasCorrect)
+        {
+            progress.ReviewInterval = 1;
+            progress.EaseFactor = Math.Max(1.3f, progress.EaseFactor - 0.2f);
+        }
+        else
+        {
+            if (progress.ReviewInterval == 1)
+            {
+                progress.ReviewInterval = 6;
+            }
+            else
+            {
+                progress.ReviewInterval = (int)(progress.ReviewInterval * progress.EaseFactor);
+                progress.ReviewInterval = Math.Min(progress.ReviewInterval, MAX_REVIEW_INTERVAL_DAYS);
+                progress.EaseFactor = Math.Min(2.5f, progress.EaseFactor + 0.1f);
+            }
+        }
+
+        progress.NextReviewDate = attemptTime.AddDays(progress.ReviewInterval);
+    }
+
+    /// <summary>
+    /// True when a context represents passive exposure (a Reading lookup / phrase cascade) rather than
+    /// an active attempt. Passive exposures are recorded as contexts but never affect streak or mastery
+    /// — they only bump exposure tracking, mirroring <c>RecordPassiveExposureAsync</c>.
+    /// </summary>
+    public static bool IsPassive(VocabularyLearningContext context) =>
+        string.Equals(context.InputMode, "Passive", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(context.ContextType, "Exposure", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Reconstructs the <see cref="VocabularyAttempt"/> that produced a persisted context, for replay.
+    /// Note: <see cref="VocabularyAttempt.PenaltyOverride"/> is not persisted on the context, so replay
+    /// falls back to the computed scaled penalty for soft-penalty activities (e.g. Conversation). This
+    /// is a negligible approximation compared with the prior behavior of destroying the history entirely.
+    /// </summary>
+    public static VocabularyAttempt ToAttempt(VocabularyLearningContext context, string vocabularyWordId, string userId) => new()
+    {
+        VocabularyWordId = vocabularyWordId,
+        UserId = userId,
+        Activity = context.Activity,
+        InputMode = context.InputMode,
+        WasCorrect = context.WasCorrect,
+        DifficultyWeight = context.DifficultyScore,
+        ContextType = context.ContextType,
+        LearningResourceId = context.LearningResourceId,
+        UserInput = context.UserInput,
+        ExpectedAnswer = context.ExpectedAnswer,
+        ResponseTimeMs = context.ResponseTimeMs,
+        UserConfidence = context.UserConfidence
+    };
+
+    /// <summary>
+    /// Resets the replay-derived fields of <paramref name="target"/> and replays every supplied context
+    /// in chronological order, producing the aggregate that would exist if all the contexts had always
+    /// belonged to a single word record. Identity fields (Id, VocabularyWordId, UserId), FirstSeenAt,
+    /// CreatedAt, and user-declared status are left untouched for the caller to manage.
+    /// </summary>
+    /// <param name="trajectory">
+    /// The mastery-after-each-active-attempt curve, suitable for charting. Passive exposures do not
+    /// emit points.
+    /// </param>
+    public static void RecalculateInto(
+        VocabularyProgress target,
+        IEnumerable<VocabularyLearningContext> contexts,
+        out List<MasteryTrajectoryPoint> trajectory)
+    {
+        target.TotalAttempts = 0;
+        target.CorrectAttempts = 0;
+        target.CurrentStreak = 0f;
+        target.ProductionInStreak = 0;
+        target.MasteryScore = 0f;
+        target.ReviewInterval = 1;
+        target.EaseFactor = 2.5f;
+        target.NextReviewDate = null;
+        target.MasteredAt = null;
+        target.ExposureCount = 0;
+        target.LastExposedAt = null;
+
+        trajectory = new List<MasteryTrajectoryPoint>();
+
+        // Defensive chronological ordering — callers should not have to guarantee sort order. CreatedAt
+        // is the stable tie-breaker for contexts that share a LearnedAt timestamp.
+        var ordered = contexts
+            .OrderBy(c => c.LearnedAt)
+            .ThenBy(c => c.CreatedAt);
+
+        foreach (var context in ordered)
+        {
+            if (IsPassive(context))
+            {
+                target.ExposureCount++;
+                target.LastExposedAt = context.LearnedAt;
+                continue;
+            }
+
+            var attempt = ToAttempt(context, target.VocabularyWordId, target.UserId);
+            ApplyAttempt(target, attempt, context.LearnedAt);
+            trajectory.Add(new MasteryTrajectoryPoint(
+                context.LearnedAt,
+                target.MasteryScore,
+                attempt.WasCorrect,
+                context.Activity ?? string.Empty,
+                context.InputMode ?? string.Empty));
+        }
+    }
+}

--- a/src/SentenceStudio.Shared/Services/VocabularyProgressService.cs
+++ b/src/SentenceStudio.Shared/Services/VocabularyProgressService.cs
@@ -15,23 +15,11 @@ public class VocabularyProgressService : IVocabularyProgressService
     private readonly IPreferencesService? _preferences;
     private readonly IServiceProvider _serviceProvider;
 
-    // NEW: Streak-based scoring constants
-    private const float MASTERY_THRESHOLD = 0.85f;                // MasteryScore threshold for "Known"
-    private const int MIN_PRODUCTION_FOR_KNOWN = 2;               // Minimum production attempts to be "Known"
-    // Issue #191: divisor raised 7.0 → 12.0 so a fresh, all-correct word
-    // doesn't reach mastery 1.0 in 5 turns. With 12.0, an all-correct fresh
-    // word lands at mastery ≈ 0.583 by turn 5 and ≈ 0.917 by turn 7, aligning
-    // mastery growth with the rotation gate in VocabularyQuizItem.ReadyToRotateOut.
-    // See .squad/decisions/inbox/wash-vocab-quiz-scoring-proposal-191.md and
-    // tools/quiz-rotation-sim/sim.py for the simulation that justifies this value.
-    private const float EFFECTIVE_STREAK_DIVISOR = 12.0f;         // EffectiveStreak / 12.0 = MasteryScore (capped at 1.0)
-
-    // Phase 0: Scoring engine constants
-    private const float WRONG_ANSWER_FLOOR = 0.6f;               // Scaled penalty never softer than this
-    private const float MAX_WRONG_PENALTY = 0.4f;                 // Maximum penalty portion for wrong answers
-    private const float MAX_STREAK_PRESERVE = 0.5f;               // Never keep more than half the streak on wrong answer
-    private const float STREAK_PRESERVE_DIVISOR = 8.0f;           // Divisor for streak preservation fraction
-    private const float RECOVERY_BOOST = 0.02f;                   // Small boost so correct answers always show progress
+    // Streak-based scoring math now lives in VocabularyMasteryCalculator — the single source of truth
+    // shared by the live attempt path, duplicate-merge recalculation, and the word-page mastery chart.
+    // The constant below is still referenced by HandleVerificationProbeResultAsync; it aliases the
+    // calculator's value so the two can never drift.
+    private const int MIN_PRODUCTION_FOR_KNOWN = VocabularyMasteryCalculator.MIN_PRODUCTION_FOR_KNOWN;
 
     // LEGACY: Old constants kept for reference during migration
     [Obsolete("Use EFFECTIVE_STREAK_DIVISOR instead")]
@@ -86,63 +74,20 @@ public class VocabularyProgressService : IVocabularyProgressService
     {
         var progress = await GetOrCreateProgressAsync(attempt.VocabularyWordId, attempt.UserId);
 
-        // Update total counts
-        progress.TotalAttempts++;
-        if (attempt.WasCorrect)
-            progress.CorrectAttempts++;
+        // Capture mastered state so the mastery transition can be logged without the pure calculator
+        // needing a logger dependency.
+        bool wasMasteredBefore = progress.MasteredAt.HasValue;
 
-        // Determine if this is a production attempt (Text or Voice input)
-        bool isProduction = attempt.InputMode == InputMode.Text.ToString() ||
-                           attempt.InputMode == InputMode.Voice.ToString() ||
-                           attempt.InputMode == "TextEntry"; // Legacy support
+        // Core streak / mastery / spaced-repetition scoring. This is shared verbatim with duplicate-merge
+        // recalculation and the word-page mastery chart via VocabularyMasteryCalculator so the live path,
+        // a merge replay, and the rendered curve can never disagree.
+        VocabularyMasteryCalculator.ApplyAttempt(progress, attempt, DateTime.Now);
 
-        // NEW: Streak-based scoring
-        if (attempt.WasCorrect)
+        if (!wasMasteredBefore && progress.MasteredAt.HasValue)
         {
-            // Correct answer: increment streak by DifficultyWeight
-            float weight = attempt.DifficultyWeight > 0 ? attempt.DifficultyWeight : 1.0f;
-            progress.CurrentStreak += weight;
-            if (isProduction)
-            {
-                progress.ProductionInStreak++;
-            }
-
-            // Calculate new MasteryScore with recovery awareness
-            float effectiveStreak = progress.CurrentStreak + (progress.ProductionInStreak * 0.5f);
-            float streakScore = MathF.Min(effectiveStreak / EFFECTIVE_STREAK_DIVISOR, 1.0f);
-            float recoveryBoost = (progress.MasteryScore > streakScore) ? RECOVERY_BOOST : 0f;
-            progress.MasteryScore = MathF.Max(streakScore, progress.MasteryScore) + recoveryBoost;
-            progress.MasteryScore = MathF.Min(progress.MasteryScore, 1.0f);
-
-            _logger.LogDebug("Correct! Word {WordId}: Streak={Streak:F1}, Weight={Weight:F1}, ProdInStreak={ProdStreak}, EffStreak={EffStreak:F1}, Mastery={Mastery:F2}",
-                progress.VocabularyWordId, progress.CurrentStreak, weight, progress.ProductionInStreak, effectiveStreak, progress.MasteryScore);
-        }
-        else
-        {
-            // Wrong answer: scaled penalty and partial streak preservation
-            // Temporal weighting — established words penalized less
-            float penaltyFactor = MathF.Max(
-                WRONG_ANSWER_FLOOR,
-                1.0f - (MAX_WRONG_PENALTY / (1f + MathF.Log(1 + progress.CorrectAttempts))));
-
-            // PenaltyOverride: if the caller provided an override (e.g., Conversation's 0.8),
-            // use it directly instead of the computed scaled penalty
-            if (attempt.PenaltyOverride.HasValue)
-            {
-                penaltyFactor = attempt.PenaltyOverride.Value;
-            }
-
-            progress.MasteryScore *= penaltyFactor;
-
-            // Partial streak preservation — experienced words keep some streak
-            float preserveFraction = MathF.Min(
-                MAX_STREAK_PRESERVE,
-                MathF.Log(1 + progress.CorrectAttempts) / STREAK_PRESERVE_DIVISOR);
-            progress.CurrentStreak = progress.CurrentStreak * preserveFraction;
-            progress.ProductionInStreak = (int)(progress.ProductionInStreak * preserveFraction);
-
-            _logger.LogDebug("Wrong! Word {WordId}: PenaltyFactor={Penalty:F2}, PreserveFrac={Preserve:F2}, Streak={Streak:F1}, Mastery={Mastery:F2}",
-                progress.VocabularyWordId, penaltyFactor, preserveFraction, progress.CurrentStreak, progress.MasteryScore);
+            _logger.LogInformation(
+                "Word {WordId} mastered. Mastery={Mastery:F2}, ProdInStreak={ProdStreak}. Next review in {Interval} days.",
+                progress.VocabularyWordId, progress.MasteryScore, progress.ProductionInStreak, progress.ReviewInterval);
         }
 
         // LEGACY: Update old phase-specific fields for backward compatibility during migration
@@ -150,29 +95,6 @@ public class VocabularyProgressService : IVocabularyProgressService
         UpdatePhaseMetrics(progress, attempt);
         UpdateLegacyFields(progress, attempt);
 #pragma warning restore CS0618
-
-        // Update spaced repetition schedule
-        UpdateSpacedRepetitionSchedule(progress, attempt);
-
-        // Update timestamps
-        progress.LastPracticedAt = DateTime.Now;
-        progress.UpdatedAt = DateTime.Now;
-
-        // Mark as mastered if threshold reached with production evidence
-        if (progress.MasteryScore >= MASTERY_THRESHOLD &&
-            progress.ProductionInStreak >= MIN_PRODUCTION_FOR_KNOWN)
-        {
-            if (!progress.MasteredAt.HasValue)
-            {
-                progress.MasteredAt = DateTime.Now;
-                _logger.LogInformation("🎉 Word {WordId} mastered! Mastery={Mastery:F2}, ProdInStreak={ProdStreak}. Next review in 60 days.",
-                    progress.VocabularyWordId, progress.MasteryScore, progress.ProductionInStreak);
-            }
-            // Known words always get a long review interval — SM-2 would
-            // set a short one since it doesn't know about mastery status
-            progress.ReviewInterval = 60;
-            progress.NextReviewDate = DateTime.Now.AddDays(60);
-        }
 
         // Save progress
         progress = await _progressRepo.SaveAsync(progress);
@@ -393,36 +315,6 @@ public class VocabularyProgressService : IVocabularyProgressService
     private void UpdateLearningPhaseRigorous(VocabularyProgress progress)
     {
         // No longer advances phases - kept for backward compatibility
-    }
-
-    private void UpdateSpacedRepetitionSchedule(VocabularyProgress progress, VocabularyAttempt attempt)
-    {
-        // Simple SM-2 algorithm implementation with safety limits
-        const int MAX_REVIEW_INTERVAL_DAYS = 365; // Cap at 1 year maximum
-
-        if (!attempt.WasCorrect)
-        {
-            // Reset on incorrect answer
-            progress.ReviewInterval = 1;
-            progress.EaseFactor = Math.Max(1.3f, progress.EaseFactor - 0.2f);
-        }
-        else
-        {
-            // Increase interval on correct answer
-            if (progress.ReviewInterval == 1)
-            {
-                progress.ReviewInterval = 6;
-            }
-            else
-            {
-                progress.ReviewInterval = (int)(progress.ReviewInterval * progress.EaseFactor);
-                // Cap the interval to prevent DateTime.AddDays overflow
-                progress.ReviewInterval = Math.Min(progress.ReviewInterval, MAX_REVIEW_INTERVAL_DAYS);
-                progress.EaseFactor = Math.Min(2.5f, progress.EaseFactor + 0.1f);
-            }
-        }
-
-        progress.NextReviewDate = DateTime.Now.AddDays(progress.ReviewInterval);
     }
 
     private Task RecordLearningContextAsync(string vocabularyProgressId, VocabularyAttempt attempt)

--- a/src/SentenceStudio.UI/Pages/VocabularyWordEdit.razor
+++ b/src/SentenceStudio.UI/Pages/VocabularyWordEdit.razor
@@ -253,6 +253,100 @@ else
                 <div class="col-8 col-md-4 ss-body2">@reviewDateText</div>
             </div>
         </div>
+
+        @* Practice History + mastery-over-time chart *@
+        <div class="card card-ss p-4 mb-3">
+            <div class="d-flex justify-content-between align-items-center gap-2 flex-wrap mb-3">
+                <h5 class="ss-title3 mb-0">@Localize["VocabWordEdit_HistoryTitle"]</h5>
+                @if (learningContexts.Count > 0)
+                {
+                    <small class="text-secondary-ss">@string.Format(Localize["VocabWordEdit_HistorySummary"], historyAttemptCount, historyExposureCount)</small>
+                }
+            </div>
+
+            @if (learningContexts.Count == 0)
+            {
+                <p class="text-secondary-ss ss-body2 mb-0 fst-italic">@Localize["VocabWordEdit_HistoryEmpty"]</p>
+            }
+            else
+            {
+                @if (masteryChartPoints.Count > 0)
+                {
+                    <div class="mb-2">
+                        <svg viewBox="0 0 320 150" width="100%" height="150" preserveAspectRatio="xMidYMid meet"
+                             role="img" aria-label='@Localize["VocabWordEdit_HistoryChartAria"]'>
+                            @* axes *@
+                            <line x1="@Svg(ChartLeftPad)" y1="@Svg(ChartTopPad)" x2="@Svg(ChartLeftPad)" y2="@Svg(chartBaselineY)" stroke="#dee2e6" stroke-width="1" />
+                            <line x1="@Svg(ChartLeftPad)" y1="@Svg(chartBaselineY)" x2="@Svg(ChartRightX)" y2="@Svg(chartBaselineY)" stroke="#dee2e6" stroke-width="1" />
+                            @* known threshold *@
+                            <line x1="@Svg(ChartLeftPad)" y1="@Svg(knownLineY)" x2="@Svg(ChartRightX)" y2="@Svg(knownLineY)" stroke="#198754" stroke-width="1" stroke-dasharray="4 3" />
+                            <text x="@Svg(ChartRightX)" y="@Svg(knownLineY - 3)" text-anchor="end" font-size="8" fill="#198754">@Localize["VocabWordEdit_HistoryKnownLine"]</text>
+                            @* y-axis labels *@
+                            <text x="@Svg(ChartLeftPad - 4)" y="@Svg(ChartTopPad + 3)" text-anchor="end" font-size="8" fill="#6c757d">100%</text>
+                            <text x="@Svg(ChartLeftPad - 4)" y="@Svg(chartBaselineY)" text-anchor="end" font-size="8" fill="#6c757d">0%</text>
+                            @* mastery line *@
+                            <polyline points="@masteryChartPolyline" fill="none" stroke="#0d6efd" stroke-width="1.5" />
+                            @* per-attempt dots *@
+                            @foreach (var p in masteryChartPoints)
+                            {
+                                <circle cx="@Svg(p.X)" cy="@Svg(p.Y)" r="2.5" fill="@(p.Correct ? "#198754" : "#dc3545")">
+                                    <title>@p.Title</title>
+                                </circle>
+                            }
+                        </svg>
+                    </div>
+                    <div class="d-flex gap-3 flex-wrap mb-3 ss-caption1 text-secondary-ss">
+                        <span><span class="d-inline-block rounded-circle me-1" style="width:8px;height:8px;background:#198754;"></span>@Localize["VocabWordEdit_HistoryCorrect"]</span>
+                        <span><span class="d-inline-block rounded-circle me-1" style="width:8px;height:8px;background:#dc3545;"></span>@Localize["VocabWordEdit_HistoryIncorrect"]</span>
+                        <span><span class="d-inline-block me-1" style="width:12px;height:0;border-top:2px dashed #198754;vertical-align:middle;"></span>@Localize["VocabWordEdit_HistoryKnownLine"]</span>
+                    </div>
+                }
+
+                @* Per-attempt entries (newest first) *@
+                <div class="vstack gap-2" style="max-height: 320px; overflow-y: auto;">
+                    @foreach (var ctx in learningContexts)
+                    {
+                        var passive = VocabularyMasteryCalculator.IsPassive(ctx);
+                        <div class="d-flex align-items-center justify-content-between gap-2 border-bottom pb-2">
+                            <div class="d-flex align-items-center gap-2">
+                                @if (passive)
+                                {
+                                    <i class="bi bi-eye text-secondary-ss"></i>
+                                }
+                                else if (ctx.WasCorrect)
+                                {
+                                    <i class="bi bi-check-circle-fill text-success"></i>
+                                }
+                                else
+                                {
+                                    <i class="bi bi-x-circle-fill text-danger"></i>
+                                }
+                                <div>
+                                    <div class="ss-body2">@ActivityLabel(ctx)</div>
+                                    <small class="text-secondary-ss">
+                                        @ctx.LearnedAt.ToString("MMM d, yyyy · h:mm tt")
+                                        @if (ctx.LearningResource != null && !string.IsNullOrWhiteSpace(ctx.LearningResource.Title))
+                                        {
+                                            <span> · @ctx.LearningResource.Title</span>
+                                        }
+                                    </small>
+                                </div>
+                            </div>
+                            <div class="text-end">
+                                @if (passive)
+                                {
+                                    <span class="badge bg-light text-secondary-ss">@Localize["VocabWordEdit_HistoryExposure"]</span>
+                                }
+                                else if (masteryAfterByContextId.TryGetValue(ctx.Id, out var m))
+                                {
+                                    <span class="badge bg-light text-dark">@((int)Math.Round(m * 100))%</span>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
+        </div>
     }
 
     @* Resource Associations *@
@@ -331,6 +425,7 @@ else
 
     [Inject] private LearningResourceRepository ResourceRepo { get; set; } = default!;
     [Inject] private VocabularyProgressService ProgressService { get; set; } = default!;
+    [Inject] private VocabularyLearningContextRepository ContextRepo { get; set; } = default!;
     [Inject] private NavigationManager NavManager { get; set; } = default!;
     [Inject] private ToastService Toast { get; set; } = default!;
     [Inject] private IJSRuntime JS { get; set; } = default!;
@@ -390,6 +485,27 @@ else
     private bool isSettingStatus;
     private bool IsExistingWord => !string.IsNullOrEmpty(Id) && Id != "0";
 
+    // Practice history + mastery-over-time chart
+    private List<VocabularyLearningContext> learningContexts = new();
+    private int historyAttemptCount;
+    private int historyExposureCount;
+    private readonly Dictionary<string, float> masteryAfterByContextId = new();
+    private readonly List<ChartPoint> masteryChartPoints = new();
+    private string masteryChartPolyline = "";
+    private double knownLineY;
+    private double chartBaselineY = 128;
+    private const double ChartLeftPad = 30;
+    private const double ChartRightPad = 12;
+    private const double ChartTopPad = 12;
+    private const double ChartBottomPad = 22;
+    private const double ChartViewWidth = 320;
+    private const double ChartViewHeight = 150;
+    private double ChartRightX => ChartViewWidth - ChartRightPad;
+
+    private readonly record struct ChartPoint(double X, double Y, bool Correct, int Pct, string Title);
+
+    private static string Svg(double v) => v.ToString("0.#", System.Globalization.CultureInfo.InvariantCulture);
+
     private bool IsFormValid =>
         !string.IsNullOrWhiteSpace(targetLanguageTerm) &&
         !string.IsNullOrWhiteSpace(nativeLanguageTerm);
@@ -445,6 +561,8 @@ else
                 originalResourceIds = new HashSet<string>(selectedResourceIds);
                 selectedConstituents = constituentWords;
                 originalConstituents = new List<VocabularyWord>(constituentWords);
+
+                await LoadHistoryAsync();
 
                 UpdateProgressDisplay();
                 UpdateEncodingStrength();
@@ -515,6 +633,106 @@ else
                 : reviewDate <= now.AddDays(7) ? $"{(reviewDate - now).Days} days away"
                 : $"{reviewDate:MMM d}";
         }
+    }
+
+    private async Task LoadHistoryAsync()
+    {
+        learningContexts = new();
+        historyAttemptCount = 0;
+        historyExposureCount = 0;
+        masteryAfterByContextId.Clear();
+        masteryChartPoints.Clear();
+        masteryChartPolyline = "";
+
+        if (progress == null)
+            return;
+
+        // GetByProgressIdAsync returns newest-first (good for the list); replay needs oldest-first.
+        learningContexts = await SafeLoadAsync(() => ContextRepo.GetByProgressIdAsync(progress.Id)) ?? new();
+        if (learningContexts.Count == 0)
+            return;
+
+        BuildMasteryTrajectory();
+    }
+
+    private void BuildMasteryTrajectory()
+    {
+        // Replay every recorded attempt chronologically through the shared scoring engine so the chart
+        // and per-entry mastery reflect exactly what the live attempt path would have produced.
+        var ordered = learningContexts
+            .OrderBy(c => c.LearnedAt)
+            .ThenBy(c => c.CreatedAt)
+            .ToList();
+
+        var clone = new VocabularyProgress
+        {
+            Id = progress!.Id,
+            VocabularyWordId = progress.VocabularyWordId,
+            UserId = progress.UserId
+        };
+
+        var correctText = $"{Localize["VocabWordEdit_HistoryCorrect"]}";
+        var incorrectText = $"{Localize["VocabWordEdit_HistoryIncorrect"]}";
+
+        var activePoints = new List<(int Pct, bool Correct, string Title)>();
+        foreach (var ctx in ordered)
+        {
+            if (VocabularyMasteryCalculator.IsPassive(ctx))
+            {
+                historyExposureCount++;
+                continue;
+            }
+
+            historyAttemptCount++;
+            var attempt = VocabularyMasteryCalculator.ToAttempt(ctx, clone.VocabularyWordId, clone.UserId);
+            VocabularyMasteryCalculator.ApplyAttempt(clone, attempt, ctx.LearnedAt);
+
+            int pct = (int)Math.Round(Math.Clamp(clone.MasteryScore, 0f, 1f) * 100);
+            masteryAfterByContextId[ctx.Id] = clone.MasteryScore;
+            string outcome = ctx.WasCorrect ? correctText : incorrectText;
+            activePoints.Add((pct, ctx.WasCorrect, $"{pct}% · {outcome} · {ctx.LearnedAt:MMM d, yyyy}"));
+        }
+
+        BuildChartGeometry(activePoints);
+    }
+
+    private void BuildChartGeometry(List<(int Pct, bool Correct, string Title)> active)
+    {
+        masteryChartPoints.Clear();
+        masteryChartPolyline = "";
+        chartBaselineY = ChartTopPad + (ChartViewHeight - ChartTopPad - ChartBottomPad);
+        knownLineY = ChartTopPad + (1 - 0.85) * (ChartViewHeight - ChartTopPad - ChartBottomPad);
+
+        if (active.Count == 0)
+            return;
+
+        double plotW = ChartViewWidth - ChartLeftPad - ChartRightPad;
+        double plotH = ChartViewHeight - ChartTopPad - ChartBottomPad;
+        int n = active.Count;
+
+        var sb = new System.Text.StringBuilder();
+        for (int i = 0; i < n; i++)
+        {
+            double x = ChartLeftPad + (n == 1 ? plotW / 2 : plotW * i / (n - 1));
+            double m = Math.Clamp(active[i].Pct / 100.0, 0.0, 1.0);
+            double y = ChartTopPad + (1 - m) * plotH;
+
+            if (i > 0) sb.Append(' ');
+            sb.Append($"{Svg(x)},{Svg(y)}");
+
+            masteryChartPoints.Add(new ChartPoint(x, y, active[i].Correct, active[i].Pct, active[i].Title));
+        }
+
+        masteryChartPolyline = sb.ToString();
+    }
+
+    private string ActivityLabel(VocabularyLearningContext ctx)
+    {
+        if (VocabularyMasteryCalculator.IsPassive(ctx))
+            return $"{Localize["VocabWordEdit_HistoryExposure"]}";
+        return string.IsNullOrWhiteSpace(ctx.Activity)
+            ? $"{Localize["VocabWordEdit_HistoryPractice"]}"
+            : ctx.Activity;
     }
 
     private void UpdateEncodingStrength()

--- a/tests/SentenceStudio.UnitTests/Data/VocabularyMergeHistoryTests.cs
+++ b/tests/SentenceStudio.UnitTests/Data/VocabularyMergeHistoryTests.cs
@@ -1,0 +1,551 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using FluentAssertions;
+using SentenceStudio.Data;
+using SentenceStudio.Services;
+using SentenceStudio.Shared.Models;
+using SentenceStudio.UnitTests.PlanGeneration;
+
+namespace SentenceStudio.UnitTests.Data;
+
+/// <summary>
+/// Regression tests for the duplicate-merge learning-history preservation fix.
+///
+/// Before the fix, <see cref="LearningResourceRepository.MergeVocabularyWordsAsync"/> only reassigned
+/// resource mappings and then deleted the duplicate <see cref="VocabularyWord"/> rows — the database's
+/// ON DELETE CASCADE then destroyed every duplicate's <see cref="VocabularyProgress"/> (mastery, streak,
+/// spaced-repetition schedule) and <see cref="VocabularyLearningContext"/> (per-attempt history). A user
+/// who had practiced a word to mastery would see it reset to Unknown after a merge.
+///
+/// These tests run against the in-memory SQLite fixture, which builds the schema WITH the real cascade
+/// relationships and enforces foreign keys, so they genuinely reproduce the original data-loss bug and
+/// prove the fix preserves and recalculates history "as if it had always been one word."
+/// </summary>
+public class VocabularyMergeHistoryTests : IClassFixture<PlanGenerationTestFixture>
+{
+    private readonly PlanGenerationTestFixture _fixture;
+
+    private const string UserA = PlanGenerationTestFixture.TestUserId;
+    private const string UserB = "test-user-2";
+
+    public VocabularyMergeHistoryTests(PlanGenerationTestFixture fixture)
+    {
+        _fixture = fixture;
+        _fixture.ClearAllData();
+        _fixture.SeedUserProfile();
+    }
+
+    // A compact description of a learning context to seed.
+    private sealed record Ctx(
+        DateTime At,
+        bool Correct,
+        string InputMode = "Text",
+        bool Passive = false,
+        string Activity = "VocabularyQuiz");
+
+    [Fact]
+    public async Task Merge_MovesAndRecalculatesProgress_AsIfAlwaysOneWord()
+    {
+        // Arrange — a user practiced the same concept under two duplicate word records.
+        var t = DateTime.UtcNow.AddDays(-10);
+        var keeper = SeedWord("사과", "apple");
+        var dup = SeedWord("사과 ", "apple (dup)");
+
+        var keeperProg = SeedProgress(keeper, UserA, new[]
+        {
+            new Ctx(t.AddMinutes(1), Correct: true, InputMode: "MultipleChoice"),
+            new Ctx(t.AddMinutes(3), Correct: true, InputMode: "Text"),
+        });
+        var dupProg = SeedProgress(dup, UserA, new[]
+        {
+            new Ctx(t.AddMinutes(2), Correct: true, InputMode: "Text"),
+            new Ctx(t.AddMinutes(4), Correct: false, InputMode: "Text"),
+        });
+
+        var oracle = BuildOracle(keeper, UserA, keeperProg, dupProg);
+
+        // Act
+        var deleted = await MergeAsync(keeper, dup);
+
+        // Assert — duplicate word is gone, keeper folded in all four attempts.
+        deleted.Should().Be(1);
+        WordExists(dup).Should().BeFalse("the duplicate word should be deleted");
+        WordExists(keeper).Should().BeTrue("the keeper word must remain");
+        GetProgress(dup, UserA).Should().BeNull("the duplicate progress row must not survive");
+
+        var merged = GetProgress(keeper, UserA);
+        merged.Should().NotBeNull();
+        merged!.TotalAttempts.Should().Be(4, "all four attempts must be preserved");
+        merged.CorrectAttempts.Should().Be(3);
+        merged.MasteryScore.Should().BeGreaterThan(0f, "mastery must NOT be reset to Unknown");
+
+        // The keeper must equal a full chronological replay of every context (the "one word" oracle).
+        merged.MasteryScore.Should().BeApproximately(oracle.MasteryScore, 0.0001f);
+        merged.CurrentStreak.Should().BeApproximately(oracle.CurrentStreak, 0.0001f);
+        merged.ProductionInStreak.Should().Be(oracle.ProductionInStreak);
+        merged.TotalAttempts.Should().Be(oracle.TotalAttempts);
+        merged.CorrectAttempts.Should().Be(oracle.CorrectAttempts);
+    }
+
+    [Fact]
+    public async Task Merge_ReParentsContexts_DoesNotCascadeDelete()
+    {
+        // Arrange — duplicate carries both active attempts and a passive exposure.
+        var t = DateTime.UtcNow.AddDays(-5);
+        var keeper = SeedWord("물", "water");
+        var dup = SeedWord("물 ", "water (dup)");
+
+        var keeperProg = SeedProgress(keeper, UserA, new[]
+        {
+            new Ctx(t.AddMinutes(1), Correct: true),
+            new Ctx(t.AddMinutes(2), Correct: true),
+        });
+        SeedProgress(dup, UserA, new[]
+        {
+            new Ctx(t.AddMinutes(3), Correct: true),
+            new Ctx(t.AddMinutes(4), Correct: false),
+            new Ctx(t.AddMinutes(5), Correct: false, Passive: true, Activity: "Reading"),
+        });
+
+        var keeperProgId = keeperProg.Id;
+        var totalContextsBefore = CountAllContexts();
+        totalContextsBefore.Should().Be(5);
+
+        // Act
+        await MergeAsync(keeper, dup);
+
+        // Assert — every context survives and is re-parented onto the keeper (none cascade-deleted).
+        CountAllContexts().Should().Be(5, "no learning context may be destroyed by the merge");
+        CountContextsFor(keeperProgId).Should().Be(5, "all contexts must now point at the keeper progress");
+
+        var merged = GetProgress(keeper, UserA)!;
+        merged.Id.Should().Be(keeperProgId, "the existing keeper progress row is retained");
+        merged.TotalAttempts.Should().Be(4, "the passive exposure is not an attempt");
+        merged.ExposureCount.Should().Be(1, "the passive exposure must be preserved as an exposure");
+    }
+
+    [Fact]
+    public async Task Merge_IsolatesProgressPerUser()
+    {
+        // Arrange — two users practiced the duplicate; only user A also practiced the keeper.
+        SeedUserProfile(UserB);
+        var t = DateTime.UtcNow.AddDays(-8);
+        var keeper = SeedWord("책", "book");
+        var dup = SeedWord("책 ", "book (dup)");
+
+        var keeperProgA = SeedProgress(keeper, UserA, new[]
+        {
+            new Ctx(t.AddMinutes(1), Correct: true),
+        });
+        var dupProgA = SeedProgress(dup, UserA, new[]
+        {
+            new Ctx(t.AddMinutes(2), Correct: true),
+            new Ctx(t.AddMinutes(3), Correct: true),
+        });
+        var dupProgB = SeedProgress(dup, UserB, new[]
+        {
+            new Ctx(t.AddMinutes(1), Correct: true),
+            new Ctx(t.AddMinutes(2), Correct: false),
+        });
+
+        var oracleA = BuildOracle(keeper, UserA, keeperProgA, dupProgA);
+        var oracleB = BuildOracle(keeper, UserB, dupProgB);
+
+        // Act
+        await MergeAsync(keeper, dup);
+
+        // Assert — each user keeps exactly one combined keeper record; users are never collapsed together.
+        GetProgress(dup, UserA).Should().BeNull();
+        GetProgress(dup, UserB).Should().BeNull();
+        CountProgressFor(keeper).Should().Be(2, "exactly one keeper progress per user");
+
+        var mergedA = GetProgress(keeper, UserA)!;
+        mergedA.TotalAttempts.Should().Be(3);
+        mergedA.MasteryScore.Should().BeApproximately(oracleA.MasteryScore, 0.0001f);
+
+        var mergedB = GetProgress(keeper, UserB)!;
+        mergedB.Should().NotBeNull("user B practiced only the duplicate, so a keeper record must be created");
+        mergedB.TotalAttempts.Should().Be(2);
+        mergedB.MasteryScore.Should().BeApproximately(oracleB.MasteryScore, 0.0001f);
+    }
+
+    [Fact]
+    public async Task Merge_AncientAggregateHistory_WithoutContexts_NeverRegresses()
+    {
+        // Arrange — the duplicate holds high mastery from before per-attempt context tracking existed,
+        // so there are no contexts to replay. The merge must not zero that mastery out.
+        var t = DateTime.UtcNow.AddDays(-30);
+        var keeper = SeedWord("학교", "school");
+        var dup = SeedWord("학교 ", "school (dup)");
+
+        SeedProgress(keeper, UserA, new[]
+        {
+            new Ctx(t.AddMinutes(1), Correct: true),
+        });
+        SeedAggregateOnlyProgress(dup, UserA,
+            masteryScore: 0.9f, totalAttempts: 20, correctAttempts: 18,
+            currentStreak: 10f, productionInStreak: 6);
+
+        // Act
+        await MergeAsync(keeper, dup);
+
+        // Assert — counts are monotonic and mastery/streak are protected from regression.
+        var merged = GetProgress(keeper, UserA)!;
+        merged.TotalAttempts.Should().Be(21, "1 context-backed + 20 ancient attempts");
+        merged.CorrectAttempts.Should().Be(19);
+        merged.MasteryScore.Should().BeGreaterThanOrEqualTo(0.9f, "ancient mastery must not be lost");
+        merged.CurrentStreak.Should().BeGreaterThanOrEqualTo(10f);
+        merged.ProductionInStreak.Should().BeGreaterThanOrEqualTo(6);
+    }
+
+    [Fact]
+    public async Task Merge_LegacyAggregateOnly_PreservesReviewSchedule()
+    {
+        // Arrange — both rows predate per-attempt context tracking, so there are no contexts to replay.
+        // The duplicate carries a real spaced-repetition schedule (due date, interval, ease). Replay would
+        // reset these to defaults (NextReviewDate=null), making the merged word never due for review again,
+        // so the merge must carry the schedule forward.
+        var keeper = SeedWord("바다", "sea");
+        var dup = SeedWord("바다 ", "sea (dup)");
+        var dueDate = DateTime.UtcNow.AddDays(9);
+
+        SeedAggregateOnlyProgress(keeper, UserA,
+            masteryScore: 0.5f, totalAttempts: 5, correctAttempts: 4,
+            currentStreak: 2f, productionInStreak: 1);
+        SeedAggregateOnlyProgress(dup, UserA,
+            masteryScore: 0.88f, totalAttempts: 30, correctAttempts: 27,
+            currentStreak: 12f, productionInStreak: 8,
+            nextReviewDate: dueDate, reviewInterval: 14, easeFactor: 2.6f);
+
+        // Act
+        await MergeAsync(keeper, dup);
+
+        // Assert — the merged keeper carries the duplicate's real review cadence forward.
+        var merged = GetProgress(keeper, UserA)!;
+        merged.NextReviewDate.Should().NotBeNull("a merged word must keep a review date so it resurfaces");
+        merged.NextReviewDate!.Value.Should().BeCloseTo(dueDate, TimeSpan.FromSeconds(1));
+        merged.ReviewInterval.Should().Be(14);
+        merged.EaseFactor.Should().BeApproximately(2.6f, 0.0001f);
+        merged.IsDueForReview.Should().BeFalse("the carried-over due date is in the future");
+    }
+
+    [Fact]
+    public async Task Merge_DeclaredFamiliarDuplicate_NeverQuizzed_PreservesScheduleAndDeclaration()
+    {
+        // Arrange — the user marked the DUPLICATE "Familiar" (a high-value "I know this" signal) but never
+        // quizzed it, so it carries a 14-day grace-period schedule with ZERO attempts. The keeper was never
+        // touched. summedTotal == 0 here, so the schedule restore must gate on the schedule's existence
+        // rather than on attempt count, otherwise the grace cadence is lost and the word goes dormant
+        // (NextReviewDate=null => never due) after the grace window — stuck Familiar with no verification probe.
+        var keeper = SeedWord("우유", "milk");
+        var dup = SeedWord("우유 ", "milk (dup)");
+        var dueDate = DateTime.UtcNow.AddDays(14);
+
+        SeedDeclaredFamiliarProgress(dup, UserA, dueDate);
+        GetProgress(keeper, UserA).Should().BeNull("keeper was never practiced or declared");
+
+        // Act
+        await MergeAsync(keeper, dup);
+
+        // Assert — the keeper carries BOTH the declaration and the review cadence forward.
+        GetProgress(dup, UserA).Should().BeNull();
+        var merged = GetProgress(keeper, UserA)!;
+        merged.IsUserDeclared.Should().BeTrue("a user-declared Familiar status is high-value signal");
+        merged.IsFamiliar.Should().BeTrue("declaration + Pending verification must survive the merge");
+        merged.NextReviewDate.Should().NotBeNull("the grace-period review date must survive the merge");
+        merged.NextReviewDate!.Value.Should().BeCloseTo(dueDate, TimeSpan.FromSeconds(1));
+        merged.ReviewInterval.Should().Be(30);
+    }
+
+    [Fact]
+    public async Task Merge_WhenOnlyDuplicatePracticed_CreatesKeeperProgress()
+    {
+        // Arrange — the keeper word was never practiced by this user; only the duplicate was.
+        var t = DateTime.UtcNow.AddDays(-3);
+        var keeper = SeedWord("의자", "chair");
+        var dup = SeedWord("의자 ", "chair (dup)");
+
+        var dupProg = SeedProgress(dup, UserA, new[]
+        {
+            new Ctx(t.AddMinutes(1), Correct: true),
+            new Ctx(t.AddMinutes(2), Correct: true),
+        });
+        GetProgress(keeper, UserA).Should().BeNull("keeper has no progress yet");
+
+        var oracle = BuildOracle(keeper, UserA, dupProg);
+
+        // Act
+        await MergeAsync(keeper, dup);
+
+        // Assert — a keeper progress record is created carrying the duplicate's history.
+        GetProgress(dup, UserA).Should().BeNull();
+        var merged = GetProgress(keeper, UserA);
+        merged.Should().NotBeNull();
+        merged!.TotalAttempts.Should().Be(2);
+        merged.MasteryScore.Should().BeGreaterThan(0f);
+        merged.MasteryScore.Should().BeApproximately(oracle.MasteryScore, 0.0001f);
+    }
+
+    [Fact]
+    public async Task LivePath_And_Replay_ProduceIdenticalAggregate()
+    {
+        // This guards the "single source of truth" guarantee: the merge recalculates by replaying
+        // contexts through VocabularyMasteryCalculator, so a replay of the live path's own contexts
+        // must reproduce the live path's aggregate exactly. If the two ever diverge, merge math is wrong.
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var progressRepo = scope.ServiceProvider.GetRequiredService<VocabularyProgressRepository>();
+        var loggerFactory = scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
+        var contextRepo = new VocabularyLearningContextRepository(
+            _fixture.ServiceProvider,
+            loggerFactory.CreateLogger<VocabularyLearningContextRepository>());
+        var service = new VocabularyProgressService(
+            progressRepo,
+            contextRepo,
+            loggerFactory.CreateLogger<VocabularyProgressService>(),
+            _fixture.ServiceProvider);
+
+        var wordId = SeedWord("사랑", "love");
+
+        var inputs = new[]
+        {
+            (Correct: true,  Mode: "MultipleChoice"),
+            (Correct: true,  Mode: "Text"),
+            (Correct: false, Mode: "Text"),
+            (Correct: true,  Mode: "Text"),
+            (Correct: true,  Mode: "MultipleChoice"),
+        };
+
+        VocabularyProgress live = null!;
+        foreach (var (correct, mode) in inputs)
+        {
+            live = await service.RecordAttemptAsync(new VocabularyAttempt
+            {
+                VocabularyWordId = wordId,
+                UserId = UserA,
+                WasCorrect = correct,
+                DifficultyWeight = 1.0f,
+                InputMode = mode,
+                Activity = "VocabularyQuiz",
+                ContextType = "Isolated"
+            });
+            await Task.Delay(3); // ensure distinct LearnedAt timestamps for a stable replay order
+        }
+
+        // Replay the live path's own persisted contexts into a fresh aggregate.
+        List<VocabularyLearningContext> contexts;
+        using (var readScope = _fixture.ServiceProvider.CreateScope())
+        {
+            var db = readScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            contexts = db.VocabularyLearningContexts.AsNoTracking()
+                .Where(c => c.VocabularyProgressId == live.Id)
+                .ToList();
+        }
+
+        contexts.Should().HaveCount(inputs.Length, "every attempt persists exactly one context");
+
+        var replay = new VocabularyProgress { Id = "replay", VocabularyWordId = wordId, UserId = UserA };
+        VocabularyMasteryCalculator.RecalculateInto(replay, contexts, out _);
+
+        replay.TotalAttempts.Should().Be(live.TotalAttempts);
+        replay.CorrectAttempts.Should().Be(live.CorrectAttempts);
+        replay.ProductionInStreak.Should().Be(live.ProductionInStreak);
+        replay.CurrentStreak.Should().BeApproximately(live.CurrentStreak, 0.0001f);
+        replay.MasteryScore.Should().BeApproximately(live.MasteryScore, 0.0001f);
+    }
+
+    #region Helpers
+
+    private string SeedWord(string target, string native)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var word = new VocabularyWord
+        {
+            Id = Guid.NewGuid().ToString(),
+            TargetLanguageTerm = target,
+            NativeLanguageTerm = native,
+            Language = "Korean",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        db.VocabularyWords.Add(word);
+        db.SaveChanges();
+        return word.Id;
+    }
+
+    private void SeedUserProfile(string userId)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        if (db.UserProfiles.Find(userId) != null)
+            return;
+        db.UserProfiles.Add(new UserProfile
+        {
+            Id = userId,
+            Name = $"User {userId}",
+            NativeLanguage = "English",
+            TargetLanguage = "Korean",
+            PreferredSessionMinutes = 20,
+            CreatedAt = DateTime.UtcNow
+        });
+        db.SaveChanges();
+    }
+
+    /// <summary>
+    /// Seeds a progress row whose aggregate is made self-consistent by replaying the given contexts —
+    /// exactly what the live path would have produced for that history.
+    /// </summary>
+    private VocabularyProgress SeedProgress(string wordId, string userId, IEnumerable<Ctx> ctxs)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var progress = new VocabularyProgress
+        {
+            Id = Guid.NewGuid().ToString(),
+            VocabularyWordId = wordId,
+            UserId = userId
+        };
+
+        var ctxList = ctxs.Select(c => new VocabularyLearningContext
+        {
+            Id = Guid.NewGuid().ToString(),
+            VocabularyProgressId = progress.Id,
+            Activity = c.Activity,
+            InputMode = c.Passive ? "Passive" : c.InputMode,
+            ContextType = c.Passive ? "Exposure" : "Isolated",
+            WasCorrect = c.Correct,
+            DifficultyScore = 1.0f,
+            LearnedAt = c.At,
+            CreatedAt = c.At,
+            UpdatedAt = c.At
+        }).ToList();
+
+        VocabularyMasteryCalculator.RecalculateInto(progress, ctxList, out _);
+        progress.FirstSeenAt = ctxList.Count > 0 ? ctxList.Min(c => c.LearnedAt) : DateTime.UtcNow;
+        progress.CreatedAt = progress.FirstSeenAt;
+
+        db.VocabularyProgresses.Add(progress);
+        db.VocabularyLearningContexts.AddRange(ctxList);
+        db.SaveChanges();
+        return progress;
+    }
+
+    /// <summary>Seeds an aggregate-only progress row (no contexts), simulating pre-context-tracking history.</summary>
+    private void SeedAggregateOnlyProgress(
+        string wordId, string userId, float masteryScore, int totalAttempts,
+        int correctAttempts, float currentStreak, int productionInStreak,
+        DateTime? nextReviewDate = null, int reviewInterval = 1, float easeFactor = 2.5f)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.VocabularyProgresses.Add(new VocabularyProgress
+        {
+            Id = Guid.NewGuid().ToString(),
+            VocabularyWordId = wordId,
+            UserId = userId,
+            MasteryScore = masteryScore,
+            TotalAttempts = totalAttempts,
+            CorrectAttempts = correctAttempts,
+            CurrentStreak = currentStreak,
+            ProductionInStreak = productionInStreak,
+            NextReviewDate = nextReviewDate,
+            ReviewInterval = reviewInterval,
+            EaseFactor = easeFactor,
+            FirstSeenAt = DateTime.UtcNow.AddDays(-60),
+            LastPracticedAt = DateTime.UtcNow.AddDays(-20),
+            CreatedAt = DateTime.UtcNow.AddDays(-60),
+            UpdatedAt = DateTime.UtcNow.AddDays(-20)
+        });
+        db.SaveChanges();
+    }
+
+    /// <summary>Seeds a user-declared "Familiar" progress row with a grace-period schedule but ZERO attempts,
+    /// mirroring SetUserDeclaredStatusAsync's Familiar branch (the user said "I know this" without quizzing).</summary>
+    private void SeedDeclaredFamiliarProgress(string wordId, string userId, DateTime nextReviewDate)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.VocabularyProgresses.Add(new VocabularyProgress
+        {
+            Id = Guid.NewGuid().ToString(),
+            VocabularyWordId = wordId,
+            UserId = userId,
+            IsUserDeclared = true,
+            UserDeclaredAt = DateTime.UtcNow.AddDays(-2),
+            VerificationState = VerificationStatus.Pending,
+            TotalAttempts = 0,
+            CorrectAttempts = 0,
+            NextReviewDate = nextReviewDate,
+            ReviewInterval = 30,
+            EaseFactor = 2.5f,
+            FirstSeenAt = DateTime.UtcNow.AddDays(-2),
+            LastPracticedAt = DateTime.UtcNow.AddDays(-2),
+            CreatedAt = DateTime.UtcNow.AddDays(-2),
+            UpdatedAt = DateTime.UtcNow.AddDays(-2)
+        });
+        db.SaveChanges();
+    }
+
+    /// <summary>Builds the "as if always one word" oracle by replaying every source's contexts.</summary>
+    private VocabularyProgress BuildOracle(string keeperWordId, string userId, params VocabularyProgress[] sources)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var ids = sources.Select(s => s.Id).ToList();
+        var contexts = db.VocabularyLearningContexts.AsNoTracking()
+            .Where(c => ids.Contains(c.VocabularyProgressId))
+            .ToList();
+
+        var oracle = new VocabularyProgress { Id = "oracle", VocabularyWordId = keeperWordId, UserId = userId };
+        VocabularyMasteryCalculator.RecalculateInto(oracle, contexts, out _);
+        return oracle;
+    }
+
+    private async Task<int> MergeAsync(string keeperWordId, params string[] dupIds)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<LearningResourceRepository>();
+        return await repo.MergeVocabularyWordsAsync(keeperWordId, dupIds.ToList());
+    }
+
+    private VocabularyProgress? GetProgress(string wordId, string userId)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return db.VocabularyProgresses.AsNoTracking()
+            .FirstOrDefault(p => p.VocabularyWordId == wordId && p.UserId == userId);
+    }
+
+    private int CountProgressFor(string wordId)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return db.VocabularyProgresses.AsNoTracking().Count(p => p.VocabularyWordId == wordId);
+    }
+
+    private int CountAllContexts()
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return db.VocabularyLearningContexts.AsNoTracking().Count();
+    }
+
+    private int CountContextsFor(string progressId)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return db.VocabularyLearningContexts.AsNoTracking().Count(c => c.VocabularyProgressId == progressId);
+    }
+
+    private bool WordExists(string wordId)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return db.VocabularyWords.AsNoTracking().Any(w => w.Id == wordId);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Problem

Merging duplicate vocabulary words **permanently destroyed all learning progress**. `MergeVocabularyWordsAsync` only reassigned resource mappings then deleted the duplicate `VocabularyWord` rows — the database's `ON DELETE CASCADE` then wiped each duplicate's `VocabularyProgress` (mastery / streak / SR schedule) and `VocabularyLearningContext` (per-attempt history). The keeper was chosen by resource count, **never by learning history**, so a heavily-practiced word reset to *Unknown* after a merge. This is the root cause of "I keep seeing words I already know."

## Fix

- **`VocabularyMasteryCalculator` (new)** — extracts all scoring math into one pure, static source of truth, reused by the live attempt path, the merge replay, **and** the word-page chart, so the three can never diverge.
- **Merge rewrite** (`MergeVocabularyWordsAsync` / `MergeLearningProgressAsync`) — re-parents every learning context onto the keeper **before** any delete, then replays them **chronologically** through the calculator so mastery is recalculated *"as if it had always been one word."* Recombines **per `UserId`** (no cross-tenant bleed), reconciles aggregate counts monotonically (never decreases), and protects pre-context legacy history from regression.
- **Spaced-repetition cadence preserved** — when replay reconstructs zero active attempts (legacy aggregate-only data, or a user-declared *"Familiar"* duplicate that was never quizzed), the real `NextReviewDate` / `ReviewInterval` / `EaseFactor` is carried forward so a merged word never silently goes dormant. Gated on `replayedActiveAttempts == 0 && scheduleSource.NextReviewDate.HasValue` so it can only restore a lost schedule, never clobber a valid replayed one.
- **Word-page Practice History card** (`VocabularyWordEdit.razor`) — inline SVG mastery-over-time chart (with the 85% "Known" line) + per-attempt entry list. EN + KO strings.

## Verification

- **Live merge on real Postgres** — drove the actual "Merge (keep best)" UI: keeper recombined mastery **0.0833 → 0.3943196** (exact match to an independent replay), **11 contexts re-parented (not deleted)**, loser rows gone, **0 orphans**.
- **Live history UI** — word-edit page rendered the chart + entries with correct per-point values.
- **Unit: 625/625 passing**, including **8 merge tests** against a **real cascade-enforcing SQLite schema** (genuinely reproduces the original data-loss bug): moves+recalculates, re-parents-not-cascade-deletes, per-user isolation, ancient-aggregate-never-regresses, legacy-aggregate-only-preserves-schedule, declared-Familiar-preserves-schedule+declaration, keeper-created-when-only-duplicate-practiced, live-path==replay parity.

## Review

Two `code-review` passes — **no blocking issues**. The one non-blocking suggestion (SR-schedule carry-over for declared-Familiar duplicates) was implemented and re-verified.

## Known limit

`PenaltyOverride` (Conversation soft-penalty) isn't persisted on contexts, so replay uses the computed scaled penalty. Currently moot (no live caller sets it); documented.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>